### PR TITLE
Add practical example for agent telemetry.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ OTLP covers multi use OpenTelemetry modules
 | Name |  Description | Agent Version | 
 | ---- |  ----------- | ------------- | 
 | [OTLP to LGTM](./modules/otlp/otlp-to-lgtm/) | Module to ingest OTLP data and then send it to Loki, Mimir and Tempo stacks locally or in GrafanaCloud. | `>= v0.33`
+| [Grafana Agent Telemetry to LGTM](./modules/grafana-agent/telemetry-to-lgtm/) | Module to forward the Grafana Agent's own telemetry data to Loki, Mimir and Tempo stacks locally or in GrafanaCloud. | `>= v0.33`

--- a/example/README.md
+++ b/example/README.md
@@ -4,8 +4,9 @@ This folder contains example modules and entrypoint parent config files for the
 Grafana Agent. This example focuses on the agent forwarding its own metrics,
 logs and traces. The purpose of the example is to demonstrate module features
 such as various module loaders, passing arguments and receiving exports. It is not
-recommended as the most efficient way to do this for production (see ./modules for
-practical modules to use).
+recommended as the most efficient way to do this for production. See
+[Grafana Agent Telemetry to LGTM](../modules/grafana-agent/telemetry-to-lgtm/) for a
+practical module to use.
 
 # Entrypoints
 

--- a/example/logs/forward_to_loki/README.md
+++ b/example/logs/forward_to_loki/README.md
@@ -1,25 +1,11 @@
 # logs/forward_to_loki
 
-> **SUPPORTED**: grafana/agent >= v0.34.0
-
 The `logs/forward_to_loki` module is an example module which exports logs
 from a log file to a loki endpoint.
 
-## Usage
+## Agent Version
 
-```river
-module.git "forward_to_loki" {
-	repository = "https://github.com/grafana/agent-modules.git"
-	revision   = "main"
-	path       = "example/logs/forward_to_loki/module.river"
-
-	arguments {
-		filepath = FILEPATH
-		url      = URL
-	}
-}
-
-```
+`>= v0.34`
 
 ## Module arguments
 

--- a/example/metrics/prometheus_receiver/README.md
+++ b/example/metrics/prometheus_receiver/README.md
@@ -1,26 +1,11 @@
 # metrics/prometheus_receiver
 
-> **SUPPORTED**: grafana/agent >= v0.34.0
-
 The `metrics/prometheus_receiver` module is an example module which exports a
 prometheus receiver for use by other components.
 
-## Usage
+## Agent Version
 
-```river
-module.git "metrics_prometheus_receiver" {
-	repository = "https://github.com/grafana/agent-modules.git"
-	revision   = "main"
-	path       = "example/metrics/prometheus_receiver/module.river"
-
-	arguments {
-		username = USERNAME
-		password = PASSWORD
-		url      = URL
-	}
-}
-
-```
+`>= v0.34`
 
 ## Module arguments
 

--- a/example/metrics/prometheus_scrape/README.md
+++ b/example/metrics/prometheus_scrape/README.md
@@ -1,25 +1,11 @@
 # metrics/prometheus_scrape
 
-> **SUPPORTED**: grafana/agent >= v0.34.0
-
 The `metrics/prometheus_scrape` module is an example module which scrapes
 metrics from a promtheus compatible endpoint and forwards them to a receiver.
 
-## Usage
+## Agent Version
 
-```river
-module.git "traces_otel_input" {
-	repository = "https://github.com/grafana/agent-modules.git"
-	revision   = "main"
-	path       = "example/traces/otel_input/module.river"
-
-	arguments {
-		address  = ADDRESS
-		receiver = RECEIVER
-	}
-}
-
-```
+`>= v0.34`
 
 ## Module arguments
 

--- a/example/traces/otel_input/README.md
+++ b/example/traces/otel_input/README.md
@@ -1,28 +1,13 @@
 # traces/otel_input
 
-> **SUPPORTED**: grafana/agent >= v0.34.0
-
 The `traces/otel_input` module is an example module which exports an otel trace
 input. That input will run the traces through the default
 `otelcol.processor.batch` settings and then forward them on to the provided
 target url.
 
-## Usage
+## Agent Version
 
-```river
-module.git "traces_otel_input" {
-	repository = "https://github.com/grafana/agent-modules.git"
-	revision   = "main"
-	path       = "example/traces/otel_input/module.river"
-
-	arguments {
-		username = USERNAME
-		password = PASSWORD
-		url      = URL
-	}
-}
-
-```
+`>= v0.34`
 
 ## Module arguments
 

--- a/modules/grafana-agent/telemetry-to-lgtm/README.md
+++ b/modules/grafana-agent/telemetry-to-lgtm/README.md
@@ -1,0 +1,67 @@
+# Grafana Agent Telemetry to LGTM Stack Module
+
+Module to forward the Grafana Agent's own telemetry data to Loki, Mimir and Tempo stacks locally or in GrafanaCloud.
+
+## Agent Version
+
+`>= v0.33`
+
+## Module arguments
+
+The following arguments are supported when passing arguments to the module
+loader:
+
+| Name | Type | Description | Default | Required
+| ---- | ---- | ----------- | ------- | --------
+| `grafana_agent_port`    | `string`   | The port the Grafana Agent is running on. | `"12345"` | no
+| `grafana_agent_logpath` | `string`   | The filepath to Grafana Agent logs | | yes
+| `prometheus_endpoint`   | `receiver` | The Prometheus remote write endpoint. | | yes
+| `prometheus_user`       | `string`   | The Prometheus remote write basic auth username. | | yes
+| `prometheus_password`   | `secret`   | The Prometheus remote write basic auth password. | | yes
+| `loki_endpoint`         | `string`   | Loki endpoint | | yes
+| `loki_user`             | `string`   | Loki basic auth username. | | yes
+| `loki_password`         | `secret`   | Loki basic auth password. | | yes
+| `tempo_endpoint`        | `string`   | Tempo Endpoint | | yes
+| `tempo_user`            | `string`   | Tempo basic auth username. | | yes
+| `tempo_password`        | `secret`   | Tempo basic auth password. | | yes
+
+Grafana Agent logs must be forwarded to the file at `grafana_agent_logpath`.
+
+## Module exports
+
+The following fields are exported by the module:
+
+| Name | Type | Description
+| ---- | ---- | -----------
+| `trace_input` | `otelcol.Consumer` | A value that other components can use to send telemetry data to.
+
+## Example
+
+```
+tracing {
+	sampling_fraction = 1
+	write_to          = [module.file.agent_telemetry.exports.trace_input]
+}
+
+module.git "agent_telemetry" {
+    repository = "https://github.com/grafana/agent-modules.git"
+    revision   = "main"
+    path       = "modules/grafana-agent/telemetry-to-lgtm/module.river"
+
+    arguments {
+        grafana_agent_logpath = "/path/to/logs.log"
+
+        prometheus_endpoint = "https://prometheus-us-central1.grafana.net/api/prom/push"
+        prometheus_user     = "123456"
+        prometheus_password = env("GRAFANA_CLOUD_KEY")
+
+        loki_endpoint = "https://logs-prod-us-central1.grafana.net/loki/api/v1/push"
+        loki_user     = "1234567"
+        loki_password = env("GRAFANA_CLOUD_KEY")
+
+        tempo_endpoint = "tempo-us-central1.grafana.net:443"
+        tempo_user     = "1234"
+        tempo_password = env("GRAFANA_CLOUD_KEY")
+    }
+}
+```

--- a/modules/grafana-agent/telemetry-to-lgtm/README.md
+++ b/modules/grafana-agent/telemetry-to-lgtm/README.md
@@ -25,7 +25,11 @@ loader:
 | `tempo_user`            | `string`   | Tempo basic auth username. | | yes
 | `tempo_password`        | `secret`   | Tempo basic auth password. | | yes
 
-Grafana Agent logs must be forwarded to the file at `grafana_agent_logpath`.
+Grafana Agent logs must be forwarded to the file at `grafana_agent_logpath`. For example:
+
+```bash
+grafana-agent run parent.river 2>${GRAFANA_AGENT_LOGPATH}
+```
 
 ## Module exports
 

--- a/modules/grafana-agent/telemetry-to-lgtm/module.river
+++ b/modules/grafana-agent/telemetry-to-lgtm/module.river
@@ -1,0 +1,106 @@
+/********************************************
+ * ARGUMENTS
+ ********************************************/
+argument "prometheus_endpoint" { }
+
+argument "prometheus_user" { }
+
+argument "prometheus_password" { }
+
+argument "loki_filepath" { }
+
+argument "loki_endpoint" { }
+
+argument "loki_user" { }
+
+argument "loki_password" { }
+
+argument "tempo_endpoint" { }
+
+argument "tempo_user" { }
+
+argument "tempo_password" { }
+
+argument "grafana_agent_port" {
+	optional = true
+	default  = "12345"
+}
+
+/********************************************
+ * EXPORTS
+ ********************************************/
+export "trace_input" {
+	value = otelcol.processor.batch.default.input
+}
+
+/********************************************
+ * AGENT METRICS
+ ********************************************/
+prometheus.remote_write "default" {
+	endpoint {
+		url = argument.prometheus_endpoint.value
+
+		basic_auth {
+			username = argument.prometheus_user.value
+			password = argument.prometheus_password.value
+		}
+	}
+}
+
+prometheus.scrape "default" {
+	targets         = [{"__address__" = "0.0.0.0:" + argument.grafana_agent_port.value}]
+	forward_to      = [prometheus.remote_write.default.receiver]
+	scrape_interval = "10s"
+}
+
+/********************************************
+ * AGENT LOGGING
+ ********************************************/
+loki.source.file "default" {
+	targets = [
+		{__path__ = argument.loki_filepath.value},
+	]
+	forward_to = [loki.write.default.receiver]
+}
+
+loki.write "default" {
+	endpoint {
+		url = argument.loki_endpoint.value
+
+		basic_auth {
+			username = argument.loki_user.value
+			password = argument.loki_password.value
+		}
+	}
+}
+
+/********************************************
+ * AGENT TRACING
+ ********************************************/
+otelcol.processor.batch "default" {
+	output {
+		traces = [otelcol.processor.memory_limiter.default.input]
+	}
+}
+
+otelcol.processor.memory_limiter "default" {
+	check_interval = "1s"
+
+	limit = "150MiB"
+
+	output {
+		traces = [otelcol.exporter.otlp.default.input]
+	}
+}
+
+otelcol.auth.basic "default" {
+	username = argument.tempo_user.value
+	password = argument.tempo_password.value
+}
+
+otelcol.exporter.otlp "default" {
+	client {
+		endpoint = argument.tempo_endpoint.value
+		auth     = otelcol.auth.basic.default.handler
+	}
+}

--- a/modules/otlp/otlp-to-lgtm/README.md
+++ b/modules/otlp/otlp-to-lgtm/README.md
@@ -2,8 +2,6 @@
 
 Module to ingest OTLP data and then send it to Loki, Mimir and Tempo stacks locally or in GrafanaCloud.
 
-
-
 ## Agent Version
 
 `>= v0.33`
@@ -27,7 +25,6 @@ loader:
 | `tempo_user`      | `string` | Tempo basic auth username. | | yes
 | `tempo_password`      | `secret` | Tempo basic auth password. | | yes
 
-
 ## Module exports
 
 The module has no exports.
@@ -41,16 +38,16 @@ module.git "otlp_to_lgtm" {
     path       = "modules/otlp/otlp-to-lgtm/module.river"
 
     arguments {
-        prometheus_endpoint = "https://prometheus-us-central1.grafana.net/api/prom"
-        prometheus_user = "123456"
+        prometheus_endpoint = "https://prometheus-us-central1.grafana.net/api/prom/push"
+        prometheus_user     = "123456"
         prometheus_password = env("GRAFANA_CLOUD_KEY")
 
-        loki_endpoint = "https://logs-prod-us-central1.grafana.net"
-        loki_user = "1234567"
+        loki_endpoint = "https://logs-prod-us-central1.grafana.net/loki/api/v1/push"
+        loki_user     = "1234567"
         loki_password = env("GRAFANA_CLOUD_KEY")
 
         tempo_endpoint = "tempo-us-central1.grafana.net:443"
-        tempo_user = "1234"
+        tempo_user     = "1234"
         tempo_password = env("GRAFANA_CLOUD_KEY")
     }
 }

--- a/modules/otlp/otlp-to-lgtm/module.river
+++ b/modules/otlp/otlp-to-lgtm/module.river
@@ -1,53 +1,42 @@
 argument "otlp_http_endpoint" {
-    optional = true
-    default = "0.0.0.0:4318"
+	optional = true
+	default  = "0.0.0.0:4318"
 }
 
 argument "otlp_grpc_endpoint" {
-    optional = true
-    default = "0.0.0.0:4317"
+	optional = true
+	default  = "0.0.0.0:4317"
 }
 
-argument "prometheus_endpoint" {
-}
+argument "prometheus_endpoint" { }
 
-argument "prometheus_user" {
-}
+argument "prometheus_user" { }
 
-argument "prometheus_password" {
-}
+argument "prometheus_password" { }
 
-argument "loki_endpoint" {
-}
+argument "loki_endpoint" { }
 
-argument "loki_user" {
-}
+argument "loki_user" { }
 
-argument "loki_password" {
-}
+argument "loki_password" { }
 
-argument "tempo_endpoint" {
-}
+argument "tempo_endpoint" { }
 
-argument "tempo_user" {
-}
+argument "tempo_user" { }
 
-argument "tempo_password" {
-}
-
-
+argument "tempo_password" { }
 
 otelcol.receiver.otlp "default" {
 	// https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.receiver.otlp/
 
-    // configures the default endpoint "0.0.0.0:4317"
+	// configures the default endpoint "0.0.0.0:4317"
 	grpc {
 		endpoint = argument.otlp_grpc_endpoint.value
 	}
-    // configures the default endpoint "0.0.0.0:4318"
+	// configures the default endpoint "0.0.0.0:4318"
 	http {
 		endpoint = argument.otlp_http_endpoint.value
-	 }
+	}
 
 	output {
 		metrics = [otelcol.processor.batch.default.input]


### PR DESCRIPTION
Format .river files.

Clean up some documentation on the way.