### PR TITLE
Fix & improve agentfmt.sh

### DIFF
--- a/modules/grafana-agent/telemetry-to-lgtm/README.md
+++ b/modules/grafana-agent/telemetry-to-lgtm/README.md
@@ -44,7 +44,7 @@ The following fields are exported by the module:
 ```
 tracing {
 	sampling_fraction = 1
-	write_to          = [module.file.agent_telemetry.exports.trace_input]
+	write_to          = [module.git.agent_telemetry.exports.trace_input]
 }
 
 module.git "agent_telemetry" {

--- a/util/agentfmt.sh
+++ b/util/agentfmt.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+
 #
 # Recursively search a directory for .river files and format them.
 #
@@ -10,9 +12,15 @@
 AGENT_DIR=$1
 TARGET_DIR=$2
 
-cd $AGENT_DIR
-find "$TARGET_DIR" -name "*.river" -print0 | while read -d $'\0' file
+echo "Building agent binary"
+pushd "$AGENT_DIR"
+    make agent
+popd
+
+
+find "$TARGET_DIR" -name "*.river" -print0 | while read -rd $'\0' file
 do
     # This should probably be more clever than having to run the go project for every file but does the job for now...
-    go run ./cmd/grafana-agent fmt -w $file
+    echo "Formatting $file"
+    AGENT_MODE=flow "$AGENT_DIR/build/grafana-agent" fmt -w "$file"
 done


### PR DESCRIPTION
Some improvements to `agentfmt.sh`
- `AGENT_MODE=flow` was not set
- relative paths didn't work
- adding execute permissions on the script
- opting to `make agent` first and use the binary to make things faster
- set flags to make sure the bash script will fail on error