### PR TITLE
host-filter: add a host filter module

### DIFF
--- a/modules/host-filter/README.md
+++ b/modules/host-filter/README.md
@@ -36,7 +36,7 @@ following values:
 * `localhost` or `127.0.0.1`
 * The value of the `hostname` argument.
 
-The `hostname` arugment defaults to the first of the following:
+The `hostname` argument defaults to the first of the following:
 
 * The `HOSTNAME` environment variable, if set.
 * The system-reported hostname.

--- a/modules/host-filter/README.md
+++ b/modules/host-filter/README.md
@@ -1,0 +1,82 @@
+# Host filtering module
+
+The host filtering module provides a Flow mode equivalent to static mode's
+[host filtering][] functionality.
+
+[host filtering]: https://grafana.com/docs/agent/latest/static/operation-guide/#host-filtering-beta
+
+## Agent Version
+
+`>= v0.34`
+
+## Module arguments
+
+The following arguments are supported when passing arguments to the module
+loader:
+
+| Name | Type | Description | Default | Required
+| ---- | ---- | ----------- | ------- | --------
+| `targets` | `list(map(string))` | Targets to filter. | | yes
+| `hostname` | `string` | Hostname to use for filtering. | _See below_ | no
+
+The `targets` argument determines the set of targets to perform host filtering
+against. The following labels are used for host filtering:
+
+* `__meta_consul_node`
+* `__meta_dockerswarm_node_id`
+* `__meta_dockerswarm_node_hostname`
+* `__meta_dockerswarm_node_address`
+* `__meta_kubernetes_pod_node_name`
+* `__meta_kubernetes_node_name`
+* `__host__`
+
+Targets are kept if the target has one of the above labels set to one of the
+following values:
+
+* `localhost` or `127.0.0.1`
+* The value of the `hostname` argument.
+
+The `hostname` arugment defaults to the first of the following:
+
+* The `HOSTNAME` environment variable, if set.
+* The system-reported hostname.
+
+## Module exports
+
+The following exports are exposed and can be used:
+
+| Name | Type | Description
+| ---- | ---- | -----------
+| `output` | `list(map(string))` | Filtered targets.
+
+## Example
+
+This example scrapes Kubernetes pods which are running on the same Kubernetes
+Node as Grafana Agent:
+
+```river
+discovery.kubernetes "pods" {
+    role = "pod"
+}
+
+module.git "host_filter" {
+    repository = "https://github.com/grafana/agent-modules.git"
+    revision   = "main"
+    path       = "modules/host-filter/module.river"
+
+    arguments {
+        targets = discovery.kubernetes.pods.targets
+    }
+}
+
+prometheus.scrape "pods" {
+    targets    = module.git.host_filter.exports.output
+    forward_to = [prometheus.remote_write.example.receiver]
+}
+
+prometheus.remote_write "example" {
+    endpoint {
+        url = PROMETHEUS_URL
+    }
+}
+```

--- a/modules/host-filter/module.river
+++ b/modules/host-filter/module.river
@@ -12,6 +12,10 @@ argument "hostname" {
 	)
 }
 
+export "output" {
+	value = discovery.relabel.host_filter.output
+}
+
 discovery.relabel "host_filter" {
 	targets = argument.targets.value
 
@@ -51,8 +55,4 @@ discovery.relabel "host_filter" {
 
 		action = "keep"
 	}
-}
-
-export "output" {
-	value = discovery.relabel.host_filter.output
 }

--- a/modules/host-filter/module.river
+++ b/modules/host-filter/module.river
@@ -1,0 +1,58 @@
+argument "targets" { }
+
+argument "hostname" {
+	optional = true
+
+	// Match static mode's behavior for how the hostname was determined, where
+	// the $HOSTNAME environment variable took precedence over the
+	// machine-reported hostname.
+	default = coalesce(
+		env("HOSTNAME"),
+		constants.hostname,
+	)
+}
+
+discovery.relabel "host_filter" {
+	targets = argument.targets.value
+
+	// Provide a set of labels which may indicate that the target comes from
+	// the same host as the one Grafana Agent is running on.
+	rule {
+		source_labels = [
+			// Labels from Consul SD.
+			"__meta_consul_node",
+
+			// Labels from Docker Swarm SD.
+			"__meta_dockerswarm_node_id",
+			"__meta_dockerswarm_node_hostname",
+			"__meta_dockerswarm_node_address",
+
+			// Labels from Kubernetes SD. Labels for `role: service` are omitted as
+			// service targets have labels merged with discovered pods.
+			"__meta_kubernetes_pod_node_name",
+			"__meta_kubernetes_node_name",
+
+			// Custom host label.
+			"__host__",
+		]
+
+		// Our in-memory string will be something like A;B;C;D;E;F, where any of
+		// the letters could be replaced with a label value or be empty if the
+		// label value did not exist.
+		//
+		// We want to search for one of the following:
+		//
+		// - localhost or 127.0.0.1
+		// - The hostname to check against.
+		//
+		// Where that text is either preceded by a colon (;B) or the start of the
+		// string (A), and succeeded by a colon (B;) or the end of the string (F).
+		regex = ".*(?:^|;)(localhost|127\\.0\\.0\\.1|" + argument.hostname.value + ")(?:;|$).*"
+
+		action = "keep"
+	}
+}
+
+export "output" {
+	value = discovery.relabel.host_filter.output
+}


### PR DESCRIPTION
The host filter module is an equivalent to static mode's [Host filtering][] capabilities.

For compatibility purposes, this module implements the same filtering behavior, although it uses relabling rules to achieve the same effect rather than manually filtering targets in code.

Note that in static mode, when host filtering is enabled, it also patches Kubernetes SD to add selectors to only discover Pods colocated to Grafana Agent. This optimizing behavior was undocumented, and can't be carried over here.

However, code which converts static mode configs to Flow mode configs may be intereted in injecting the same selector when host filtering is used in static mode.

[Host filtering]: https://grafana.com/docs/agent/latest/static/operation-guide/#host-filtering-beta