### PR TITLE
feat: add new module to autoconfigure grafana cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,5 @@ OTLP covers multi use OpenTelemetry modules
 | Name |  Description | Agent Version | 
 | ---- |  ----------- | ------------- | 
 | [OTLP to LGTM](./modules/otlp/otlp-to-lgtm/) | Module to ingest OTLP data and then send it to Loki, Mimir and Tempo stacks locally or in GrafanaCloud. | `>= v0.33`
-| [Grafana Agent Telemetry to LGTM](./modules/grafana-agent/telemetry-to-lgtm/) | Module to forward the Grafana Agent's own telemetry data to Loki, Mimir and Tempo stacks locally or in GrafanaCloud. | `>= v0.33`
+| [Grafana Agent Telemetry to LGTM](./modules/grafana-agent/telemetry-to-lgtm/) | Module to forward the Grafana Agent's own telemetry data to Loki, Mimir and Tempo stacks locally or in Grafana Cloud. | `>= v0.33`
+| [Grafana Cloud Autoconfigure](./modules/grafana-cloud/autoconfigure/) | Module to automatically configure receivers for Grafana Cloud. | `>= v0.34`

--- a/modules/grafana-cloud/autoconfigure/README.md
+++ b/modules/grafana-cloud/autoconfigure/README.md
@@ -1,0 +1,63 @@
+# Grafana Cloud Autoconfigure Module
+
+Module to automatically configure receivers for Grafana Cloud.
+
+## Agent Version
+
+`>= v0.34`
+
+## Module arguments
+
+The following arguments are supported when passing arguments to the module
+loader:
+
+| Name | Type | Description | Default | Required
+| ---- | ---- | ----------- | ------- | --------
+| `stack_name`  | `string`   | Name of your stack as shown in the account console | | yes
+| `token` | `secret` | Access policy token or API Key. | | yes
+
+To create a token:
+1. Navigate to the [Grafana Cloud Portal](https://grafana.com/profile/org)
+1. Go to either the `Access Policies` or `API Keys` page, located in the `Security` section
+1. Create an Access Policy or API token with the correct permissions
+
+The token must have permissions to read stack information. The setup of these permissions depends on the type of token:
+
+* Access Policies need the `stacks:read` scope
+* API Keys need at least the the `MetricsPublisher` role
+
+## Module exports
+
+The following fields are exported by the module:
+
+| Name | Type | Description
+| ---- | ---- | -----------
+| `metrics_receiver` | `prometheus.Interceptor` | A value that other components can use to send metrics data to.
+| `logs_receiver` | `loki.LogsReceiver` | A value that other components can use to send logs data to.
+| `traces_receiver` | `otelcol.Consumer` | A value that other components can use to send trace data to.
+| `profiles_receiver` | `write.fanOutClient` | A value that other components can use to send profiling data to.
+| `stack_information` | `object` | Decoded representation of the [Stack info endpoint](https://grafana.com/docs/grafana-cloud/api-reference/cloud-api/#stacks).
+
+## Example
+
+```
+module.git "grafana_cloud" {
+    repository = "https://github.com/grafana/agent-modules.git"
+    revision   = "main"
+    path       = "modules/grafana-cloud/autoconfigure/module.river"
+
+    arguments {
+        stack_name = "<your-stack-name>"
+        token      = "<your-access-token>"
+    }
+}
+
+prometheus.scrape "default" {
+  targets = [
+    {"__address__" = "127.0.0.1:12345"},
+  ]
+  forward_to = [
+    module.git.grafana_cloud.exports.metrics_receiver,
+  ]
+}
+```

--- a/modules/grafana-cloud/autoconfigure/module.river
+++ b/modules/grafana-cloud/autoconfigure/module.river
@@ -1,0 +1,95 @@
+/********************************************
+ * ARGUMENTS
+ ********************************************/
+argument "stack_name" { }
+
+argument "token" {}
+
+/********************************************
+ * EXPORTS
+ ********************************************/
+
+export "metrics_receiver" {
+  value = prometheus.remote_write.default.receiver
+}
+
+export "logs_receiver" {
+  value = loki.write.default.receiver
+}
+
+export "traces_receiver" {
+  value = otelcol.exporter.otlp.default.input
+}
+
+export "profiles_receiver" {
+  value = pyroscope.write.default.receiver
+}
+
+export "stack_information" {
+  value = json_decode(remote.http.config_file.content)
+}
+
+/********************************************
+ * External information
+ ********************************************/
+
+remote.http "config_file" {
+  url = "https://grafana.com/api/instances/" + argument.stack_name.value
+  client {
+    bearer_token = argument.token.value
+  }
+  poll_frequency = "24h"
+}
+
+/********************************************
+ * Endpoints
+ ********************************************/
+
+// Metrics
+prometheus.remote_write "default" {
+  endpoint {
+    url = json_decode(remote.http.config_file.content)["hmInstancePromUrl"] + "/api/prom/push"
+
+    basic_auth {
+      username = json_decode(remote.http.config_file.content)["hmInstancePromId"]
+      password = argument.token.value
+    }
+  }
+}
+
+// Logs
+loki.write "default" {
+  endpoint {
+    url = json_decode(remote.http.config_file.content)["hlInstanceUrl"] + "/loki/api/v1/push"
+
+    basic_auth {
+      username = json_decode(remote.http.config_file.content)["hlInstanceId"]
+      password = argument.token.value
+    }
+  }
+}
+
+// Traces
+otelcol.auth.basic "default" {
+  username = json_decode(remote.http.config_file.content)["htInstanceId"]
+  password = argument.token.value
+}
+
+otelcol.exporter.otlp "default" {
+  client {
+    endpoint = json_decode(remote.http.config_file.content)["htInstanceUrl"] + ":443"
+    auth     = otelcol.auth.basic.default.handler
+  }
+}
+
+// Profiles
+pyroscope.write "default" {
+  endpoint {
+    url = json_decode(remote.http.config_file.content)["hpInstanceUrl"]
+
+    basic_auth {
+      username = json_decode(remote.http.config_file.content)["hpInstanceId"]
+      password = argument.token.value
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a new module to simplify connecting to Grafana cloud by only having to specify the stack name and token.