### PR TITLE
Updated Metric and Log Annotation Jobs

### DIFF
--- a/modules/kubernetes/README.md
+++ b/modules/kubernetes/README.md
@@ -8,7 +8,7 @@ The following pod annotations are supported:
 | :--------------- | :-----------|
 | `logs.agent.grafana.com/scrape` | Allow a pod to declare it's logs should be dropped. |
 | `logs.agent.grafana.com/tenant` | Allow a pod to override the tenant for its logs. |
-| `logs.agent.grafana.com/log-format` | If specified additional processing is performed to extract details based on the specified format.  The following formats are currently supported: <ul><li>common-log<li>donet<li>istio<li>json<li>klog<li>log4j<li>logfmt<li>otel<li>postgres<li>python<li>spring-boot<li>zerolog</ul> |
+| `logs.agent.grafana.com/log-format` | If specified additional processing is performed to extract details based on the specified format.  This value can be a comma-delimited list, in the instances a pod may have multiple containers.  The following formats are currently supported: <ul><li>common-log<li>donet<li>istio<li>json<li>klog<li>log4j<li>logfmt<li>otel<li>postgres<li>python<li>spring-boot<li>syslog<li>zerolog</ul> |
 | `logs.agent.grafana.com/scrub-level` | Boolean whether or not the level should be dropped from the log message (as it is a label). |
 | `logs.agent.grafana.com/scrub-timestamp` | Boolean whether or not the timestamp should be dropped from the log message (as it is metadata). |
 | `logs.agent.grafana.com/scrub-nulls` | Boolean whether or not keys with null values should be dropped from json, reducing the size of the log message. |
@@ -27,11 +27,11 @@ The following pod annotations are supported:
 ---
 ## Metrics
 
-The following pod annotations are supported are supported for gathering of metrics:
+The following pod annotations are supported are supported for gathering of metrics for pods and endpoints:
 
 | Annotation       | Description |
 | :--------------- | :-----------|
-| `metrics.agent.grafana.com/scrape` <br> `prometheus.io/scrape` | Boolean whether or not to scrape the endpoint / pod for metrics. *Note*: If a pod exposes multiple ports, all ports would be scraped for metrics.  To limit this behavior specify the port annotation to limit the scrape to a single port. |
+| `metrics.agent.grafana.com/scrape` <br> `prometheus.io/scrape` | Boolean whether or not to scrape the endpoint / pod for metrics. *Note*: If a pod exposes multiple ports, all ports would be scraped for metrics.  To limit this behavior specify the port annotation to limit the scrape to a single port. If the label `prometheus.io/service-monitor` or `metrics.agent.grafana.com/service-monitor` is set to `"false"` that is interpreted as a `scrape: "false"` |
 | `metrics.agent.grafana.com/scheme` <br> `prometheus.io/scheme` | The default scraping scheme is `http`, this can be specified as a single value which would override, the schema being used for all ports attached to the endpoint / pod. |
 | `metrics.agent.grafana.com/path` <br> `prometheus.io/path` | The default path to scrape is `/metrics`, this can be specified as a single value which would override, the scrape path being used for all ports attached to the endpoint / pod. |
 | `metrics.agent.grafana.com/port` <br> `prometheus.io/port` | The default port to scrape is the endpoint port, this can be specified as a single value which would override the scrape port being used for all ports attached to the endpoint, note that even if aan endpoint had multiple targets, the relabel_config targets are deduped before scraping |
@@ -40,7 +40,7 @@ The following pod annotations are supported are supported for gathering of metri
 | `metrics.agent.grafana.com/interval` <br> `prometheus.io/interval` | The default interval to scrape is `1m`, this can be specified as a single value which would override, the scrape interval being used for all ports attached to the endpoint / pod. |
 | `metrics.agent.grafana.com/timeout` <br> `prometheus.io/timeout` | The default timeout for scraping is `10s`, this can be specified as a single value which would override, the scrape interval being used for all ports attached to the endpoint / pod. |
 
-The following pod annotations are supported are supported for probes and the gathering of metrics from blackbox exporter:
+The following service / ingress annotations are supported are supported for probes and the gathering of metrics from blackbox exporter:
 
 | Annotation       | Description |
 | :--------------- | :-----------|

--- a/modules/kubernetes/logs/all.river
+++ b/modules/kubernetes/logs/all.river
@@ -117,7 +117,7 @@ module.git "log_level_default" {
   path = "modules/kubernetes/logs/labels/log-level.river"
 
   arguments {
-    forward_to = module.git.scrub_all.exports.process.receiver
+    forward_to = module.git.drop_levels.exports.process.receiver
   }
 }
 

--- a/modules/kubernetes/logs/all.river
+++ b/modules/kubernetes/logs/all.river
@@ -57,6 +57,7 @@ argument "keep_labels" {
     "instance",
     "job",
     "level",
+    "log_type",
     "namespace",
     "region",
     "service",

--- a/modules/kubernetes/logs/labels/keep-labels.river
+++ b/modules/kubernetes/logs/labels/keep-labels.river
@@ -24,6 +24,7 @@ argument "keep_labels" {
     "instance",
     "job",
     "level",
+    "log_type",
     "namespace",
     "region",
     "service",

--- a/modules/kubernetes/logs/labels/log-level.river
+++ b/modules/kubernetes/logs/labels/log-level.river
@@ -9,7 +9,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.log_level
 }
@@ -25,6 +24,19 @@ loki.process "log_level" {
     stage.static_labels {
       values = {
         level = "unknown",
+      }
+    }
+
+  }
+
+  // if a log_type is not set, default it to unknown
+  stage.match {
+    selector = "{log_type=\"\"}"
+
+    // default level to unknown
+    stage.static_labels {
+      values = {
+        log_type = "unknown",
       }
     }
 

--- a/modules/kubernetes/logs/log-formats/all.river
+++ b/modules/kubernetes/logs/log-formats/all.river
@@ -23,7 +23,73 @@ argument "git_pull_freq" {
 }
 
 export "process" {
-  value = module.git.log_format_logfmt.exports.process
+  value = module.git.log_format_common_log.exports.process
+}
+
+module.git "log_format_common_log" {
+  repository = argument.git_repo.value
+  revision = argument.git_rev.value
+  pull_frequency = argument.git_pull_freq.value
+  path = "modules/kubernetes/logs/log-formats/common-log.river"
+
+  arguments {
+    forward_to = module.git.log_format_dotnet.exports.process.receiver
+  }
+}
+
+module.git "log_format_dotnet" {
+  repository = argument.git_repo.value
+  revision = argument.git_rev.value
+  pull_frequency = argument.git_pull_freq.value
+  path = "modules/kubernetes/logs/log-formats/dotnet.river"
+
+  arguments {
+    forward_to = module.git.log_format_istio.exports.process.receiver
+  }
+}
+
+module.git "log_format_istio" {
+  repository = argument.git_repo.value
+  revision = argument.git_rev.value
+  pull_frequency = argument.git_pull_freq.value
+  path = "modules/kubernetes/logs/log-formats/istio.river"
+
+  arguments {
+    forward_to = module.git.log_format_json.exports.process.receiver
+  }
+}
+
+module.git "log_format_json" {
+  repository = argument.git_repo.value
+  revision = argument.git_rev.value
+  pull_frequency = argument.git_pull_freq.value
+  path = "modules/kubernetes/logs/log-formats/json.river"
+
+  arguments {
+    forward_to = module.git.log_format_klog.exports.process.receiver
+  }
+}
+
+module.git "log_format_klog" {
+  repository = argument.git_repo.value
+  revision = argument.git_rev.value
+  pull_frequency = argument.git_pull_freq.value
+  path = "modules/kubernetes/logs/log-formats/klog.river"
+
+  arguments {
+    forward_to = module.git.log_format_log4j.exports.process.receiver
+  }
+}
+
+module.git "log_format_log4j" {
+  repository = argument.git_repo.value
+  revision = argument.git_rev.value
+  pull_frequency = argument.git_pull_freq.value
+  path = "modules/kubernetes/logs/log-formats/log4j.river"
+
+  arguments {
+    forward_to = module.git.log_format_logfmt.exports.process.receiver
+  }
 }
 
 module.git "log_format_logfmt" {
@@ -31,6 +97,72 @@ module.git "log_format_logfmt" {
   revision = argument.git_rev.value
   pull_frequency = argument.git_pull_freq.value
   path = "modules/kubernetes/logs/log-formats/logfmt.river"
+
+  arguments {
+    forward_to = module.git.log_format_otel.exports.process.receiver
+  }
+}
+
+module.git "log_format_otel" {
+  repository = argument.git_repo.value
+  revision = argument.git_rev.value
+  pull_frequency = argument.git_pull_freq.value
+  path = "modules/kubernetes/logs/log-formats/otel.river"
+
+  arguments {
+    forward_to = module.git.log_format_postgres.exports.process.receiver
+  }
+}
+
+module.git "log_format_postgres" {
+  repository = argument.git_repo.value
+  revision = argument.git_rev.value
+  pull_frequency = argument.git_pull_freq.value
+  path = "modules/kubernetes/logs/log-formats/otel.river"
+
+  arguments {
+    forward_to = module.git.log_format_python.exports.process.receiver
+  }
+}
+
+module.git "log_format_python" {
+  repository = argument.git_repo.value
+  revision = argument.git_rev.value
+  pull_frequency = argument.git_pull_freq.value
+  path = "modules/kubernetes/logs/log-formats/python.river"
+
+  arguments {
+    forward_to = module.git.log_format_spring_boot.exports.process.receiver
+  }
+}
+
+module.git "log_format_spring_boot" {
+  repository = argument.git_repo.value
+  revision = argument.git_rev.value
+  pull_frequency = argument.git_pull_freq.value
+  path = "modules/kubernetes/logs/log-formats/spring-boot.river"
+
+  arguments {
+    forward_to = module.git.log_format_zerolog.exports.process.receiver
+  }
+}
+
+module.git "log_format_syslog" {
+  repository = argument.git_repo.value
+  revision = argument.git_rev.value
+  pull_frequency = argument.git_pull_freq.value
+  path = "modules/kubernetes/logs/log-formats/syslog.river"
+
+  arguments {
+    forward_to = module.git.log_format_zerolog.exports.process.receiver
+  }
+}
+
+module.git "log_format_zerolog" {
+  repository = argument.git_repo.value
+  revision = argument.git_rev.value
+  pull_frequency = argument.git_pull_freq.value
+  path = "modules/kubernetes/logs/log-formats/spring-boot.river"
 
   arguments {
     forward_to = argument.forward_to.value

--- a/modules/kubernetes/logs/log-formats/all.river
+++ b/modules/kubernetes/logs/log-formats/all.river
@@ -144,6 +144,17 @@ module.git "log_format_spring_boot" {
   path = "modules/kubernetes/logs/log-formats/spring-boot.river"
 
   arguments {
+    forward_to = module.git.log_format_syslog.exports.process.receiver
+  }
+}
+
+module.git "log_format_syslog" {
+  repository = argument.git_repo.value
+  revision = argument.git_rev.value
+  pull_frequency = argument.git_pull_freq.value
+  path = "modules/kubernetes/logs/log-formats/syslog.river"
+
+  arguments {
     forward_to = module.git.log_format_zerolog.exports.process.receiver
   }
 }

--- a/modules/kubernetes/logs/log-formats/all.river
+++ b/modules/kubernetes/logs/log-formats/all.river
@@ -143,17 +143,6 @@ module.git "log_format_spring_boot" {
   path = "modules/kubernetes/logs/log-formats/spring-boot.river"
 
   arguments {
-    forward_to = module.git.log_format_syslog.exports.process.receiver
-  }
-}
-
-module.git "log_format_syslog" {
-  repository = argument.git_repo.value
-  revision = argument.git_rev.value
-  pull_frequency = argument.git_pull_freq.value
-  path = "modules/kubernetes/logs/log-formats/syslog.river"
-
-  arguments {
     forward_to = module.git.log_format_zerolog.exports.process.receiver
   }
 }

--- a/modules/kubernetes/logs/log-formats/all.river
+++ b/modules/kubernetes/logs/log-formats/all.river
@@ -143,7 +143,7 @@ module.git "log_format_spring_boot" {
   path = "modules/kubernetes/logs/log-formats/spring-boot.river"
 
   arguments {
-    forward_to = module.git.log_format_zerolog.exports.process.receiver
+    forward_to = module.git.log_format_syslog.exports.process.receiver
   }
 }
 

--- a/modules/kubernetes/logs/log-formats/all.river
+++ b/modules/kubernetes/logs/log-formats/all.river
@@ -23,73 +23,7 @@ argument "git_pull_freq" {
 }
 
 export "process" {
-  value = module.git.log_format_common_log.exports.process
-}
-
-module.git "log_format_common_log" {
-  repository = argument.git_repo.value
-  revision = argument.git_rev.value
-  pull_frequency = argument.git_pull_freq.value
-  path = "modules/kubernetes/logs/log-formats/common-log.river"
-
-  arguments {
-    forward_to = module.git.log_format_dotnet.exports.process.receiver
-  }
-}
-
-module.git "log_format_dotnet" {
-  repository = argument.git_repo.value
-  revision = argument.git_rev.value
-  pull_frequency = argument.git_pull_freq.value
-  path = "modules/kubernetes/logs/log-formats/dotnet.river"
-
-  arguments {
-    forward_to = module.git.log_format_istio.exports.process.receiver
-  }
-}
-
-module.git "log_format_istio" {
-  repository = argument.git_repo.value
-  revision = argument.git_rev.value
-  pull_frequency = argument.git_pull_freq.value
-  path = "modules/kubernetes/logs/log-formats/istio.river"
-
-  arguments {
-    forward_to = module.git.log_format_json.exports.process.receiver
-  }
-}
-
-module.git "log_format_json" {
-  repository = argument.git_repo.value
-  revision = argument.git_rev.value
-  pull_frequency = argument.git_pull_freq.value
-  path = "modules/kubernetes/logs/log-formats/json.river"
-
-  arguments {
-    forward_to = module.git.log_format_klog.exports.process.receiver
-  }
-}
-
-module.git "log_format_klog" {
-  repository = argument.git_repo.value
-  revision = argument.git_rev.value
-  pull_frequency = argument.git_pull_freq.value
-  path = "modules/kubernetes/logs/log-formats/klog.river"
-
-  arguments {
-    forward_to = module.git.log_format_log4j.exports.process.receiver
-  }
-}
-
-module.git "log_format_log4j" {
-  repository = argument.git_repo.value
-  revision = argument.git_rev.value
-  pull_frequency = argument.git_pull_freq.value
-  path = "modules/kubernetes/logs/log-formats/log4j.river"
-
-  arguments {
-    forward_to = module.git.log_format_logfmt.exports.process.receiver
-  }
+  value = module.git.log_format_logfmt.exports.process
 }
 
 module.git "log_format_logfmt" {
@@ -97,61 +31,6 @@ module.git "log_format_logfmt" {
   revision = argument.git_rev.value
   pull_frequency = argument.git_pull_freq.value
   path = "modules/kubernetes/logs/log-formats/logfmt.river"
-
-  arguments {
-    forward_to = module.git.log_format_otel.exports.process.receiver
-  }
-}
-
-module.git "log_format_otel" {
-  repository = argument.git_repo.value
-  revision = argument.git_rev.value
-  pull_frequency = argument.git_pull_freq.value
-  path = "modules/kubernetes/logs/log-formats/otel.river"
-
-  arguments {
-    forward_to = module.git.log_format_postgres.exports.process.receiver
-  }
-}
-
-module.git "log_format_postgres" {
-  repository = argument.git_repo.value
-  revision = argument.git_rev.value
-  pull_frequency = argument.git_pull_freq.value
-  path = "modules/kubernetes/logs/log-formats/otel.river"
-
-  arguments {
-    forward_to = module.git.log_format_python.exports.process.receiver
-  }
-}
-
-module.git "log_format_python" {
-  repository = argument.git_repo.value
-  revision = argument.git_rev.value
-  pull_frequency = argument.git_pull_freq.value
-  path = "modules/kubernetes/logs/log-formats/python.river"
-
-  arguments {
-    forward_to = module.git.log_format_spring_boot.exports.process.receiver
-  }
-}
-
-module.git "log_format_spring_boot" {
-  repository = argument.git_repo.value
-  revision = argument.git_rev.value
-  pull_frequency = argument.git_pull_freq.value
-  path = "modules/kubernetes/logs/log-formats/spring-boot.river"
-
-  arguments {
-    forward_to = module.git.log_format_zerolog.exports.process.receiver
-  }
-}
-
-module.git "log_format_zerolog" {
-  repository = argument.git_repo.value
-  revision = argument.git_rev.value
-  pull_frequency = argument.git_pull_freq.value
-  path = "modules/kubernetes/logs/log-formats/spring-boot.river"
 
   arguments {
     forward_to = argument.forward_to.value

--- a/modules/kubernetes/logs/log-formats/all.river
+++ b/modules/kubernetes/logs/log-formats/all.river
@@ -7,7 +7,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 argument "git_repo" {
   optional = true
   default = coalesce(env("GIT_REPO"), "https://github.com/grafana/agent-modules.git")

--- a/modules/kubernetes/logs/log-formats/common-log.river
+++ b/modules/kubernetes/logs/log-formats/common-log.river
@@ -19,7 +19,7 @@ loki.process "log_format_clf" {
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: clf"
     // unescaped regex: \S+\s+\S+\s+\S+\s+\[\S+\s+\S+\]\s+"[^"]+"\s+\d+\s+\d+
-    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*((apache|nginx|common-?log|clf))\\s*,?[^\"]*\"} |~ \"^\\S+\\s+\\S+\\s+\\S+\\s+\\[\\S+\\s+\\S+\\]\\s+\"[^\"]+\"\\s+\\d+\\s+\\d+$\""
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*((apache|nginx|common-?log|clf)).*\"} |~ \"^\\\\S+\\\\s+\\\\S+\\\\s+\\\\S+\\\\s+\\\\[\\\\S+\\\\s+\\\\S+\\\\]\\\\s+\\\"[^\\\"]+\\\"\\\\s+\\\\d+\\\\s+\\\\d+$\""
 
     // clf doesn't have a log level, set default to info, set the log_type
     stage.static_labels{

--- a/modules/kubernetes/logs/log-formats/common-log.river
+++ b/modules/kubernetes/logs/log-formats/common-log.river
@@ -8,7 +8,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.log_format_clf
 }
@@ -16,15 +15,17 @@ export "process" {
 loki.process "log_format_clf" {
   forward_to = [argument.forward_to.value]
 
-  // check logs.agent.grafana.com/log-format annotation, if set to clf then process the line as clf
+  // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains clf and the line matches the format, then process the line as clf
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: clf"
-    selector = "{logs_agent_grafana_com_log_format=~\"(?i)(apache|nginx|common-?log|clf)\"}"
+    // unescaped regex: \S+\s+\S+\s+\S+\s+\[\S+\s+\S+\]\s+"[^"]+"\s+\d+\s+\d+
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*((apache|nginx|common-?log|clf))\\s*,?[^\"]*\"} |~ \"^\\S+\\s+\\S+\\s+\\S+\\s+\\[\\S+\\s+\\S+\\]\\s+\"[^\"]+\"\\s+\\d+\\s+\\d+$\""
 
-    // clf doesn't have a log level, set default to info
+    // clf doesn't have a log level, set default to info, set the log_type
     stage.static_labels{
       values = {
         level = "info",
+        log_type = "clf",
       }
     }
 

--- a/modules/kubernetes/logs/log-formats/dotnet.river
+++ b/modules/kubernetes/logs/log-formats/dotnet.river
@@ -18,7 +18,8 @@ loki.process "log_format_dotnet" {
   // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains python-json and the line matches the format, then process the line as python-json
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: dotnet-json"
-    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*(dotnet-?json)\\s*,?[^\"]*\"} |~ \"^\\s*\{.+\}\\s*$\""
+    // unescaped regex: ^\s*\{.+\}\s*$
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*(dotnet-?json).**\"} |~ \"^\\\\s*\\\\{.+\\\\}\\\\s*$\""
 
     // set the log_type
     stage.static_labels{

--- a/modules/kubernetes/logs/log-formats/dotnet.river
+++ b/modules/kubernetes/logs/log-formats/dotnet.river
@@ -19,7 +19,7 @@ loki.process "log_format_dotnet" {
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: dotnet-json"
     // unescaped regex: ^\s*\{.+\}\s*$
-    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*(dotnet-?json).**\"} |~ \"^\\\\s*\\\\{.+\\\\}\\\\s*$\""
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*(dotnet-?json).*\"} |~ \"^\\\\s*\\\\{.+\\\\}\\\\s*$\""
 
     // set the log_type
     stage.static_labels{

--- a/modules/kubernetes/logs/log-formats/dotnet.river
+++ b/modules/kubernetes/logs/log-formats/dotnet.river
@@ -8,7 +8,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.log_format_dotnet
 }
@@ -16,10 +15,17 @@ export "process" {
 loki.process "log_format_dotnet" {
   forward_to = [argument.forward_to.value]
 
-  // check logs.agent.grafana.com/log-format annotation, if set to python-json then process the line as python-json
+  // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains python-json and the line matches the format, then process the line as python-json
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: dotnet-json"
-    selector = "{logs_agent_grafana_com_log_format=~\"(?i)dotnet-?json\"}"
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*(dotnet-?json)\\s*,?[^\"]*\"} |~ \"^\\s*\{.+\}\\s*$\""
+
+    // set the log_type
+    stage.static_labels{
+      values = {
+        log_type = "dotnet",
+      }
+    }
 
     // extract the level, response_code, method if they exist
     stage.json {

--- a/modules/kubernetes/logs/log-formats/istio.river
+++ b/modules/kubernetes/logs/log-formats/istio.river
@@ -18,7 +18,7 @@ loki.process "log_format_istio" {
   // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains istio and the line matches the format, then process the line as json
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: istio"
-    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*(istio-?(json)?)\\s*,?[^\"]*\"} |~ \"^\\s*\{.+\}\\s*$\""
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*(istio-?(json)?).*\"} |~ \"^\\\\s*\\\\{.+\\\\}\\\\s*$\""
 
     // not all istio logs contain a level, default to info and set the log_type
     stage.static_labels{

--- a/modules/kubernetes/logs/log-formats/istio.river
+++ b/modules/kubernetes/logs/log-formats/istio.river
@@ -8,7 +8,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.log_format_istio
 }
@@ -16,15 +15,16 @@ export "process" {
 loki.process "log_format_istio" {
   forward_to = [argument.forward_to.value]
 
-  // check logs.agent.grafana.com/log-format annotation, if set to istio then process the line as json
+  // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains istio and the line matches the format, then process the line as json
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: istio"
-    selector = "{logs_agent_grafana_com_log_format=~\"(?i)istio-?(json)?\"}"
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*(istio-?(json)?)\\s*,?[^\"]*\"} |~ \"^\\s*\{.+\}\\s*$\""
 
-    // not all istio logs contain a level, default to info
+    // not all istio logs contain a level, default to info and set the log_type
     stage.static_labels{
       values = {
         level = "info",
+        log_type = "istio",
       }
     }
 

--- a/modules/kubernetes/logs/log-formats/json.river
+++ b/modules/kubernetes/logs/log-formats/json.river
@@ -7,7 +7,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.log_format_json
 }
@@ -15,10 +14,17 @@ export "process" {
 loki.process "log_format_json" {
   forward_to = [argument.forward_to.value]
 
-  // check logs.agent.grafana.com/log-format annotation, if set to json then process the line as json
+  // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains json and the line matches the format, then process the line as json
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: json"
-    selector = "{logs_agent_grafana_com_log_format=~\"(?i)(generic-?)?json\"}"
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*((generic-?)?json)\\s*,?[^\"]*\"} |~ \"^\\s*\{.+\}\\s*$\""
+
+    // set the log_type
+    stage.static_labels{
+      values = {
+        log_type = "json",
+      }
+    }
 
     // extract the level
     stage.json {

--- a/modules/kubernetes/logs/log-formats/json.river
+++ b/modules/kubernetes/logs/log-formats/json.river
@@ -17,7 +17,7 @@ loki.process "log_format_json" {
   // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains json and the line matches the format, then process the line as json
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: json"
-    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*((generic-?)?json)\\s*,?[^\"]*\"} |~ \"^\\s*\{.+\}\\s*$\""
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*((generic-?)?json).*\"} |~ \"^\\\\s*\\\\{.+\\\\}\\\\s*$\""
 
     // set the log_type
     stage.static_labels{

--- a/modules/kubernetes/logs/log-formats/klog.river
+++ b/modules/kubernetes/logs/log-formats/klog.river
@@ -8,7 +8,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.log_format_klog
 }
@@ -16,11 +15,19 @@ export "process" {
 loki.process "log_format_klog" {
   forward_to = [argument.forward_to.value]
 
-  // check logs.agent.grafana.com/log-format annotation, if set to klog then process the line as
+  // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains klog and the line matches the format, then process the line as
   // a klog (https://github.com/kubernetes/klog)
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: klog"
-    selector = "{logs_agent_grafana_com_log_format=~\"(?i)klog\"}"
+    // unescaped regex: ^[IWED]\d+\s+\d{2}:\d{2}:\d{2}\.\d+\s+\d+\s+\S+:\d+\]\s+.*$
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*(klog)\\s*,?[^\"]*\"} |~ \"^[IWED]\\d+\\s+\\d{2}:\\d{2}:\\d{2}\\.\\d+\\s+\\d+\\s+\\S+:\\d+\\]\\s+.*$\""
+
+    // set the log_type
+    stage.static_labels{
+      values = {
+        log_type = "klog",
+      }
+    }
 
     // extract log level, klog uses a single letter code for the level followed by the month and day i.e. I0119
     stage.regex {

--- a/modules/kubernetes/logs/log-formats/klog.river
+++ b/modules/kubernetes/logs/log-formats/klog.river
@@ -20,7 +20,7 @@ loki.process "log_format_klog" {
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: klog"
     // unescaped regex: ^[IWED]\d+\s+\d{2}:\d{2}:\d{2}\.\d+\s+\d+\s+\S+:\d+\]\s+.*$
-    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*(klog)\\s*,?[^\"]*\"} |~ \"^[IWED]\\d+\\s+\\d{2}:\\d{2}:\\d{2}\\.\\d+\\s+\\d+\\s+\\S+:\\d+\\]\\s+.*$\""
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*(klog).*\"} |~ \"^[IWED]\\\\d+\\\\s+\\\\d{2}:\\\\d{2}:\\\\d{2}\\\\.\\\\d+\\\\s+\\\\d+\\\\s+\\\\S+:\\\\d+\\\\]\\\\s+.*$\""
 
     // set the log_type
     stage.static_labels{

--- a/modules/kubernetes/logs/log-formats/log4j.river
+++ b/modules/kubernetes/logs/log-formats/log4j.river
@@ -9,7 +9,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.log_format_log4j
 }
@@ -17,10 +16,17 @@ export "process" {
 loki.process "log_format_log4j" {
   forward_to = [argument.forward_to.value]
 
-  // check logs.agent.grafana.com/log-format annotation, if set to log4j-json then process the line as log4j-json
+  // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains log4j-json and the line matches the format, then process the line as log4j-json
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: log4j-json"
-    selector = "{logs_agent_grafana_com_log_format=~\"(?i)log4j-?json\"}"
+    selector = "{logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?(log4j-?json),?[^\"]*\"} |~ \"^\\s*\{.+\}\\s*$\""
+
+    // set the log_type
+    stage.static_labels{
+      values = {
+        log_type = "log4j",
+      }
+    }
 
     stage.json {
       expressions = {
@@ -75,10 +81,18 @@ loki.process "log_format_log4j" {
 
   }
 
-  // check logs.agent.grafana.com/log-format annotation, if set to log4j-text then process the line as log4j-text
+  // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains log4j-text and the line matches the format, then process the line as log4j-text
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: log4j-text"
-    selector = "{logs_agent_grafana_com_log_format=~\"(?i)log4j(-?te?xt)?\"}"
+    // unescaped regex: ^\d{4}[^\[]+\[\S+\]\s+\w+\s+\S+\s+-\s+.*$
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*(log4j(-?te?xt)?)\\s*,?[^\"]*\"} |~ \"^\\d{4}[^\\[]+\\[\\S+\\]\\s+\\w+\\s+\\S+\\s+-\\s+.*$\""
+
+    // set the log_type
+    stage.static_labels{
+      values = {
+        log_type = "log4j",
+      }
+    }
 
     // extract the timestamp, level, traceId, spanId, processId, thread, logger from the log line
     stage.regex {

--- a/modules/kubernetes/logs/log-formats/log4j.river
+++ b/modules/kubernetes/logs/log-formats/log4j.river
@@ -19,7 +19,7 @@ loki.process "log_format_log4j" {
   // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains log4j-json and the line matches the format, then process the line as log4j-json
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: log4j-json"
-    selector = "{logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?(log4j-?json),?[^\"]*\"} |~ \"^\\s*\{.+\}\\s*$\""
+    selector = "{logs_agent_grafana_com_log_format=~\"(?i).*(log4j-?json).*\"} |~ \"^\\\\s*\\\\{.+\\\\}\\\\s*$\""
 
     // set the log_type
     stage.static_labels{
@@ -85,7 +85,7 @@ loki.process "log_format_log4j" {
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: log4j-text"
     // unescaped regex: ^\d{4}[^\[]+\[\S+\]\s+\w+\s+\S+\s+-\s+.*$
-    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*(log4j(-?te?xt)?)\\s*,?[^\"]*\"} |~ \"^\\d{4}[^\\[]+\\[\\S+\\]\\s+\\w+\\s+\\S+\\s+-\\s+.*$\""
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*(log4j(-?te?xt)?).*\"} |~ \"^\\\\d{4}[^\\\\[]+\\\\[\\\\S+\\\\]\\\\s+\\\\w+\\\\s+\\\\S+\\\\s+-\\\\s+.*$\""
 
     // set the log_type
     stage.static_labels{

--- a/modules/kubernetes/logs/log-formats/logfmt.river
+++ b/modules/kubernetes/logs/log-formats/logfmt.river
@@ -19,7 +19,7 @@ loki.process "log_format_logfmt" {
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: logfmt"
     // unescaped regex: (\w+=("[^"]*"|\S+))(\s+(\w+=("[^"]*"|\S+)))*\s*
-    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*(logfmt)\\s*,?[^\"]*\"}"
+    selector = "{logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*(logfmt)\\s*,?[^\"]*\"}"
 
     // set the log_type
     stage.static_labels{

--- a/modules/kubernetes/logs/log-formats/logfmt.river
+++ b/modules/kubernetes/logs/log-formats/logfmt.river
@@ -19,7 +19,7 @@ loki.process "log_format_logfmt" {
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: logfmt"
     // unescaped regex: (\w+=("[^"]*"|\S+))(\s+(\w+=("[^"]*"|\S+)))*\s*
-    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*(logfmt)\\s*,?[^\"]*\"} |~ \"(\\w+=(\"[^\"]*\"|\\S+))(\\s+(\\w+=(\"[^\"]*\"|\\S+)))*\\s*\""
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*(logfmt)\\s*,?[^\"]*\"}"
 
     // set the log_type
     stage.static_labels{

--- a/modules/kubernetes/logs/log-formats/logfmt.river
+++ b/modules/kubernetes/logs/log-formats/logfmt.river
@@ -20,7 +20,7 @@ loki.process "log_format_logfmt" {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: logfmt"
     // unescaped label regex: (?i)(\s*(\w|-)+\s*,)*(?P<format>logfmt)(,\s*(\w|-)+\s*)*
     // unescaped regex: (\w+=("[^"]*"|\S+))(\s+(\w+=("[^"]*"|\S+)))*\s*
-    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*(logfmt).*\"}\""
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*(logfmt).*\"}"
 
     // set the log_type
     stage.static_labels{

--- a/modules/kubernetes/logs/log-formats/logfmt.river
+++ b/modules/kubernetes/logs/log-formats/logfmt.river
@@ -20,7 +20,7 @@ loki.process "log_format_logfmt" {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: logfmt"
     // unescaped label regex: (?i)(\s*(\w|-)+\s*,)*(?P<format>logfmt)(,\s*(\w|-)+\s*)*
     // unescaped regex: (\w+=("[^"]*"|\S+))(\s+(\w+=("[^"]*"|\S+)))*\s*
-    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)(\\s*(\\w|-)+\\s*,)*(?P<format>logfmt)(,\\s*(\\w|-)+\\s*)*\"} |~ \"(\\w+=(\"[^\"]*\"|\\S+))(\\s+(\\w+=(\"[^\"]*\"|\\S+)))*\\s*\""
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)(\\s*(\\w|-)+\\s*,)*(?P<format>logfmt)(,\\s*(\\w|-)+\\s*)*\"}"
 
     // set the log_type
     stage.static_labels{

--- a/modules/kubernetes/logs/log-formats/logfmt.river
+++ b/modules/kubernetes/logs/log-formats/logfmt.river
@@ -18,9 +18,8 @@ loki.process "log_format_logfmt" {
   // a logfmt (https://github.com/go-logfmt/logfmt)
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: logfmt"
-    // unescaped label regex: (?i)(\s*(\w|-)+\s*,)*(?P<format>logfmt)(,\s*(\w|-)+\s*)*
     // unescaped regex: (\w+=("[^"]*"|\S+))(\s+(\w+=("[^"]*"|\S+)))*\s*
-    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*(logfmt).*\"}"
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*(logfmt).*\"} |~ \"(\\w+=(\"[^\"]*\"|\\S+))(\\s+(\\w+=(\"[^\"]*\"|\\S+)))*\\s*\""
 
     // set the log_type
     stage.static_labels{

--- a/modules/kubernetes/logs/log-formats/logfmt.river
+++ b/modules/kubernetes/logs/log-formats/logfmt.river
@@ -19,7 +19,7 @@ loki.process "log_format_logfmt" {
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: logfmt"
     // unescaped regex: (\w+=("[^"]*"|\S+))(\s+(\w+=("[^"]*"|\S+)))*\s*
-    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*(logfmt).*\"} |~ \"(\\w+=(\"[^\"]*\"|\\S+))(\\s+(\\w+=(\"[^\"]*\"|\\S+)))*\\s*\""
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*(logfmt).*\"} |~ \"(\\\\w+=(\"[^\"]*\"|\\\\S+))(\\\\s+(\\\\w+=(\"[^\"]*\"|\\\\S+)))*\\\\s*\""
 
     // set the log_type
     stage.static_labels{

--- a/modules/kubernetes/logs/log-formats/logfmt.river
+++ b/modules/kubernetes/logs/log-formats/logfmt.river
@@ -18,8 +18,9 @@ loki.process "log_format_logfmt" {
   // a logfmt (https://github.com/go-logfmt/logfmt)
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: logfmt"
+    // unescaped label regex: (?i)(\s*(\w|-)+\s*,)*(?P<format>logfmt)(,\s*(\w|-)+\s*)*
     // unescaped regex: (\w+=("[^"]*"|\S+))(\s+(\w+=("[^"]*"|\S+)))*\s*
-    selector = "{logs_agent_grafana_com_log_format=~\"(?i)logfmt\"}"
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)(\\s*(\\w|-)+\\s*,)*(?P<format>logfmt)(,\\s*(\\w|-)+\\s*)*\"} |~ \"(\\w+=(\"[^\"]*\"|\\S+))(\\s+(\\w+=(\"[^\"]*\"|\\S+)))*\\s*\""
 
     // set the log_type
     stage.static_labels{

--- a/modules/kubernetes/logs/log-formats/logfmt.river
+++ b/modules/kubernetes/logs/log-formats/logfmt.river
@@ -7,7 +7,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.log_format_logfmt
 }
@@ -15,11 +14,19 @@ export "process" {
 loki.process "log_format_logfmt" {
   forward_to = [argument.forward_to.value]
 
-  // check logs.agent.grafana.com/log-format annotation, if set to logfmt then process the line as
+  // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains logfmt and the line matches the format, then process the line as
   // a logfmt (https://github.com/go-logfmt/logfmt)
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: logfmt"
-    selector = "{logs_agent_grafana_com_log_format=~\"(?i)logfmt\"}"
+    // unescaped regex: (\w+=("[^"]*"|\S+))(\s+(\w+=("[^"]*"|\S+)))*\s*
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*(logfmt)\\s*,?[^\"]*\"} |~ \"(\\w+=(\"[^\"]*\"|\\S+))(\\s+(\\w+=(\"[^\"]*\"|\\S+)))*\\s*\""
+
+    // set the log_type
+    stage.static_labels{
+      values = {
+        log_type = "logfmt",
+      }
+    }
 
     // while the level could be extracted as logfmt, this allows for multiple possible log levels formats
     // i.e. loglevel=info, level=info, lvl=info, loglvl=info

--- a/modules/kubernetes/logs/log-formats/logfmt.river
+++ b/modules/kubernetes/logs/log-formats/logfmt.river
@@ -19,7 +19,7 @@ loki.process "log_format_logfmt" {
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: logfmt"
     // unescaped regex: (\w+=("[^"]*"|\S+))(\s+(\w+=("[^"]*"|\S+)))*\s*
-    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*(logfmt).*\"} |~ \"(\\\\w+=(\"[^\"]*\"|\\\\S+))(\\\\s+(\\\\w+=(\"[^\"]*\"|\\\\S+)))*\\\\s*\""
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*(logfmt).*\"} |~ \"(\\\\w+=(\\\"[^\\\"]*\\\"|\\\\S+))(\\\\s+(\\\\w+=(\\\"[^\\\"]*\\\"|\\\\S+)))*\\\\s*\""
 
     // set the log_type
     stage.static_labels{

--- a/modules/kubernetes/logs/log-formats/logfmt.river
+++ b/modules/kubernetes/logs/log-formats/logfmt.river
@@ -20,7 +20,7 @@ loki.process "log_format_logfmt" {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: logfmt"
     // unescaped label regex: (?i)(\s*(\w|-)+\s*,)*(?P<format>logfmt)(,\s*(\w|-)+\s*)*
     // unescaped regex: (\w+=("[^"]*"|\S+))(\s+(\w+=("[^"]*"|\S+)))*\s*
-    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)(\\s*(\\w|-)+\\s*,)*(?P<format>logfmt)(,\\s*(\\w|-)+\\s*)*\"}"
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*(logfmt).*\"}\""
 
     // set the log_type
     stage.static_labels{

--- a/modules/kubernetes/logs/log-formats/logfmt.river
+++ b/modules/kubernetes/logs/log-formats/logfmt.river
@@ -19,7 +19,7 @@ loki.process "log_format_logfmt" {
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: logfmt"
     // unescaped regex: (\w+=("[^"]*"|\S+))(\s+(\w+=("[^"]*"|\S+)))*\s*
-    selector = "{logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*(logfmt)\\s*,?[^\"]*\"}"
+    selector = "{logs_agent_grafana_com_log_format=~\"(?i)logfmt\"}"
 
     // set the log_type
     stage.static_labels{

--- a/modules/kubernetes/logs/log-formats/otel.river
+++ b/modules/kubernetes/logs/log-formats/otel.river
@@ -8,7 +8,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.log_format_otel
 }
@@ -16,10 +15,17 @@ export "process" {
 loki.process "log_format_otel" {
   forward_to = [argument.forward_to.value]
 
-  // check logs.agent.grafana.com/log-format annotation, if set to otel then process the line as otel
+  // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains otel and the line matches the format, then process the line as otel
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: otel"
-    selector = "{logs_agent_grafana_com_log_format=~\"(?i)(otel|open-?telemetry)(-?json)?\"}"
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*((otel|open-?telemetry)(-?json))\\s*,?[^\"]*\"} |~ \"^\\s*\{.+\}\\s*$\""
+
+    // set the log_type
+    stage.static_labels{
+      values = {
+        log_type = "otel",
+      }
+    }
 
     // extract the SeverityText (level), and service.name
     // Docs: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#service

--- a/modules/kubernetes/logs/log-formats/otel.river
+++ b/modules/kubernetes/logs/log-formats/otel.river
@@ -18,7 +18,7 @@ loki.process "log_format_otel" {
   // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains otel and the line matches the format, then process the line as otel
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: otel"
-    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*((otel|open-?telemetry)(-?json))\\s*,?[^\"]*\"} |~ \"^\\s*\{.+\}\\s*$\""
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*((otel|open-?telemetry)(-?json)).*\"} |~ \"^\\\\s*\\\\{.+\\\\}\\\\s*$\""
 
     // set the log_type
     stage.static_labels{

--- a/modules/kubernetes/logs/log-formats/postgres.river
+++ b/modules/kubernetes/logs/log-formats/postgres.river
@@ -18,7 +18,7 @@ loki.process "log_format_postgres" {
   // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains postgres then process the line
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: postgres"
-    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*(postgres)\\s*,?[^\"]*\"}"
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*(postgres).*\"}"
 
     // set the log_type
     stage.static_labels{

--- a/modules/kubernetes/logs/log-formats/postgres.river
+++ b/modules/kubernetes/logs/log-formats/postgres.river
@@ -8,7 +8,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.log_format_postgres
 }
@@ -16,10 +15,17 @@ export "process" {
 loki.process "log_format_postgres" {
   forward_to = [argument.forward_to.value]
 
-  // check logs.agent.grafana.com/log-format annotation, if set to postgres then process the line
+  // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains postgres then process the line
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: postgres"
-    selector = "{logs_agent_grafana_com_log_format=~\"(?i)postgres\"}"
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*(postgres)\\s*,?[^\"]*\"}"
+
+    // set the log_type
+    stage.static_labels{
+      values = {
+        log_type = "postgres",
+      }
+    }
 
     // extract the level and process_id from the log
     // unescaped regex: \[?(?P<timestamp>\d{4}-\d{2}-\d{2}(T|\s+)\d{2}:\d{2}:\d{2}.\d+\s+\w+)\]?\s+(\[(?P<process_id>\d+)\]\s+|.+)(?P<level>(INFO|NOTICE|WARNING|ERROR|LOG|FATAL|PANIC|DEBUG)\d*):\s*

--- a/modules/kubernetes/logs/log-formats/python.river
+++ b/modules/kubernetes/logs/log-formats/python.river
@@ -7,7 +7,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.log_format_python
 }
@@ -15,10 +14,17 @@ export "process" {
 loki.process "log_format_python" {
   forward_to = [argument.forward_to.value]
 
-  // check logs.agent.grafana.com/log-format annotation, if set to python-json then process the line as python-json
+  // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains python-json and the line matches the format, then process the line as python-json
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: python-json"
-    selector = "{logs_agent_grafana_com_log_format=~\"(?i)python-?json\"}"
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*(python-?json)\\s*,?[^\"]*\"} |~ \"^\\s*\{.+\}\\s*$\""
+
+    // set the log_type
+    stage.static_labels{
+      values = {
+        log_type = "python",
+      }
+    }
 
     // extract the level, response_code, method if they exist
     stage.json {

--- a/modules/kubernetes/logs/log-formats/python.river
+++ b/modules/kubernetes/logs/log-formats/python.river
@@ -17,7 +17,7 @@ loki.process "log_format_python" {
   // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains python-json and the line matches the format, then process the line as python-json
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: python-json"
-    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*(python-?json)\\s*,?[^\"]*\"} |~ \"^\\s*\{.+\}\\s*$\""
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*(python-?json).*\"} |~ \"^\\\\s*\\\\{.+\\\\}\\\\s*$\""
 
     // set the log_type
     stage.static_labels{

--- a/modules/kubernetes/logs/log-formats/spring-boot.river
+++ b/modules/kubernetes/logs/log-formats/spring-boot.river
@@ -8,7 +8,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.log_format_spring_boot
 }
@@ -16,10 +15,18 @@ export "process" {
 loki.process "log_format_spring_boot" {
   forward_to = [argument.forward_to.value]
 
-  // check logs.agent.grafana.com/log-format annotation, if set to springboot then process the line as spring-boot
+  // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains springboot and the line matches the format, then process the line as spring-boot
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: spring-boot"
-    selector = "{logs_agent_grafana_com_log_format=~\"(?i)spring-?boot\"}"
+    // unescaped regex: ^\d{4}.+(INFO|ERROR|WARN|DEBUG|TRACE)\s+\d+\s+[^\[]+\[\S+\]\s+\S+\s+:\s+.*$
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*(spring-?boot)\\s*,?[^\"]*\"} |~ \"^\\d{4}.+(INFO|ERROR|WARN|DEBUG|TRACE)\\s+\\d+\\s+[^\\[]+\\[\\S+\\]\\s+\\S+\\s+:\\s+.*$\""
+
+    // set the log_type
+    stage.static_labels{
+      values = {
+        log_type = "spring-boot",
+      }
+    }
 
     // extract the timestamp, level, traceId, spanId, processId, thread, logger from the log line
     stage.regex {

--- a/modules/kubernetes/logs/log-formats/spring-boot.river
+++ b/modules/kubernetes/logs/log-formats/spring-boot.river
@@ -19,7 +19,7 @@ loki.process "log_format_spring_boot" {
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: spring-boot"
     // unescaped regex: ^\d{4}.+(INFO|ERROR|WARN|DEBUG|TRACE)\s+\d+\s+[^\[]+\[\S+\]\s+\S+\s+:\s+.*$
-    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*(spring-?boot)\\s*,?[^\"]*\"} |~ \"^\\d{4}.+(INFO|ERROR|WARN|DEBUG|TRACE)\\s+\\d+\\s+[^\\[]+\\[\\S+\\]\\s+\\S+\\s+:\\s+.*$\""
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*(spring-?boot).*\"} |~ \"^\\\\d{4}.+(INFO|ERROR|WARN|DEBUG|TRACE)\\\\s+\\\\d+\\\\s+[^\\\\[]+\\\\[\\\\S+\\\\]\\\\s+\\\\S+\\\\s+:\\\\s+.*$\""
 
     // set the log_type
     stage.static_labels{

--- a/modules/kubernetes/logs/log-formats/syslog.river
+++ b/modules/kubernetes/logs/log-formats/syslog.river
@@ -1,0 +1,47 @@
+/*
+Module: log-format-syslog
+Description: Handles formatting for log format of syslog
+Docs: https://datatracker.ietf.org/doc/html/rfc5424
+*/
+argument "forward_to" {
+  // comment = "The module to forward the output to"
+  optional = false
+}
+
+export "process" {
+  value = loki.process.log_format_postgres
+}
+
+loki.process "log_format_postgres" {
+  forward_to = [argument.forward_to.value]
+
+  // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains postgres then process the line
+  stage.match {
+    pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: syslog"
+    // unescaped regex: ^[A-Za-z]{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\S+\s+\S+\[\d+\]:\s+.*$
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*(syslog)\\s*,?[^\"]*\"} |~ \"^[A-Za-z]{3}\\s+\\d{1,2}\\s+\\d{2}:\\d{2}:\\d{2}\\s+\\S+\\s+\\S+\\[\\d+\\]:\\s+.*$\""
+
+    // set the log_type
+    stage.static_labels{
+      values = {
+        log_type = "syslog",
+      }
+    }
+
+    // check logs.agent.grafana.com/scrub-timestamp annotation, if true remove the timestamp from the log line
+    // this can reduce the overall # of bytes sent and stored in Loki
+    stage.match {
+      selector = "{logs_agent_grafana_com_scrub_timestamp=\"true\"}"
+      pipeline_name = "pipeline for annotation || logs.agent.grafana.com/scrub-timestamp: true"
+
+      // remove timestamp from the log line
+      // unescaped regex: ^[A-Za-z]{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}
+      stage.replace {
+        expression = "(^[A-Za-z]{3}\\s+\\d{1,2}\\s+\\d{2}:\\d{2}:\\d{2})"
+        replace = ""
+      }
+    }
+
+  }
+
+}

--- a/modules/kubernetes/logs/log-formats/syslog.river
+++ b/modules/kubernetes/logs/log-formats/syslog.river
@@ -19,7 +19,7 @@ loki.process "log_format_postgres" {
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: syslog"
     // unescaped regex: ^[A-Za-z]{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\S+\s+\S+\[\d+\]:\s+.*$
-    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)[^\"]*,?\\s*(syslog)\\s*,?[^\"]*\"} |~ \"^[A-Za-z]{3}\\s+\\d{1,2}\\s+\\d{2}:\\d{2}:\\d{2}\\s+\\S+\\s+\\S+\\[\\d+\\]:\\s+.*$\""
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*(syslog).*\"} |~ \"^[A-Za-z]{3}\\\\s+\\\\d{1,2}\\\\s+\\\\d{2}:\\\\d{2}:\\\\d{2}\\\\s+\\\\S+\\\\s+\\\\S+\\\\[\\\\d+\\\\]:\\\\s+.*$\""
 
     // set the log_type
     stage.static_labels{

--- a/modules/kubernetes/logs/log-formats/zerolog.river
+++ b/modules/kubernetes/logs/log-formats/zerolog.river
@@ -19,7 +19,7 @@ loki.process "log_format_zerolog" {
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: zerolog"
     // unescaped regex: ^.+(TRC|DBG|INF|WRN|ERR|FTL|PNC)[^=]+(\w+=("[^"]*"|\S+))(\s+(\w+=("[^"]*"|\S+)))*\s*$
-    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)(?i)[^\"]*,?\\s*(zero-?log)\\s*,?[^\"]*\"} |~ \"^.+(TRC|DBG|INF|WRN|ERR|FTL|PNC)[^=]+(\w+=(\"[^\"]*\"|\\S+))(\\s+(\\w+=(\"[^\"]*\"|\\S+)))*\\s*$"
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*(zero-?log).*\"} |~ \"^.+(TRC|DBG|INF|WRN|ERR|FTL|PNC)[^=]+(\\\\w+=(\\\"[^\\\"]*\\\"|\\\\S+))(\\\\s+(\\\\w+=(\\\"[^\\\"]*\\\"|\\\\S+)))*\\\\s*$"
 
     // set the log_type
     stage.static_labels{

--- a/modules/kubernetes/logs/log-formats/zerolog.river
+++ b/modules/kubernetes/logs/log-formats/zerolog.river
@@ -19,7 +19,7 @@ loki.process "log_format_zerolog" {
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: zerolog"
     // unescaped regex: ^.+(TRC|DBG|INF|WRN|ERR|FTL|PNC)[^=]+(\w+=("[^"]*"|\S+))(\s+(\w+=("[^"]*"|\S+)))*\s*$
-    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*(zero-?log).*\"} |~ \"^.+(TRC|DBG|INF|WRN|ERR|FTL|PNC)[^=]+(\\\\w+=(\\\"[^\\\"]*\\\"|\\\\S+))(\\\\s+(\\\\w+=(\\\"[^\\\"]*\\\"|\\\\S+)))*\\\\s*$"
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i).*(zero-?log).*\"} |~ \"^.+(TRC|DBG|INF|WRN|ERR|FTL|PNC)[^=]+(\\\\w+=(\\\"[^\\\"]*\\\"|\\\\S+))(\\\\s+(\\\\w+=(\\\"[^\\\"]*\\\"|\\\\S+)))*\\\\s*$\""
 
     // set the log_type
     stage.static_labels{

--- a/modules/kubernetes/logs/log-formats/zerolog.river
+++ b/modules/kubernetes/logs/log-formats/zerolog.river
@@ -8,7 +8,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.log_format_zerolog
 }
@@ -16,10 +15,18 @@ export "process" {
 loki.process "log_format_zerolog" {
   forward_to = [argument.forward_to.value]
 
-  // check logs.agent.grafana.com/log-format annotation, if set to postgres then process the line
+  // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains postgres then process the line
   stage.match {
     pipeline_name = "pipeline for annotation || logs.agent.grafana.com/log-format: zerolog"
-    selector = "{logs_agent_grafana_com_log_format=~\"(?i)zero-?log\"}"
+    // unescaped regex: ^.+(TRC|DBG|INF|WRN|ERR|FTL|PNC)[^=]+(\w+=("[^"]*"|\S+))(\s+(\w+=("[^"]*"|\S+)))*\s*$
+    selector = "{log_type=\"\", logs_agent_grafana_com_log_format=~\"(?i)(?i)[^\"]*,?\\s*(zero-?log)\\s*,?[^\"]*\"} |~ \"^.+(TRC|DBG|INF|WRN|ERR|FTL|PNC)[^=]+(\w+=(\"[^\"]*\"|\\S+))(\\s+(\\w+=(\"[^\"]*\"|\\S+)))*\\s*$"
+
+    // set the log_type
+    stage.static_labels{
+      values = {
+        log_type = "zerolog",
+      }
+    }
 
     // extract the level from the log
     // unescaped regex: (?P<timestamp>[0-9]{4}-[0-9]{2}-[0-9]{2}(T|\s+)[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]+[^ ]*\s+)(?P<level>(TRC|DBG|INF|WRN|ERR|FTL|PNC)).+

--- a/modules/kubernetes/metrics/all.river
+++ b/modules/kubernetes/metrics/all.river
@@ -140,22 +140,6 @@ module.git "scrape_kube_apiserver" {
   }
 }
 
-module.git "scrape_kube_dns" {
-  repository = argument.git_repo.value
-  revision = argument.git_rev.value
-  pull_frequency = argument.git_pull_freq.value
-  path = "modules/kubernetes/metrics/scrapes/kube-dns.river"
-
-  arguments {
-    forward_to = [prometheus.remote_write.destination.receiver]
-    tenant = argument.tenant.value
-    clustering = argument.clustering.value
-    git_repo = argument.git_repo.value
-    git_rev = argument.git_rev.value
-    git_pull_freq = argument.git_pull_freq.value
-  }
-}
-
 module.git "scrape_endpoints" {
   repository = argument.git_repo.value
   revision = argument.git_rev.value

--- a/modules/kubernetes/metrics/all.river
+++ b/modules/kubernetes/metrics/all.river
@@ -157,22 +157,6 @@ module.git "scrape_endpoints" {
   }
 }
 
-module.git "scrape_pods" {
-  repository = argument.git_repo.value
-  revision = argument.git_rev.value
-  pull_frequency = argument.git_pull_freq.value
-  path = "modules/kubernetes/metrics/scrapes/auto-scrape-pods.river"
-
-  arguments {
-    forward_to = [prometheus.remote_write.destination.receiver]
-    tenant = argument.tenant.value
-    clustering = argument.clustering.value
-    git_repo = argument.git_repo.value
-    git_rev = argument.git_rev.value
-    git_pull_freq = argument.git_pull_freq.value
-  }
-}
-
 module.git "probe_services" {
   repository = argument.git_repo.value
   revision = argument.git_rev.value

--- a/modules/kubernetes/metrics/relabelings/annotations/metrics/endpoints.river
+++ b/modules/kubernetes/metrics/relabelings/annotations/metrics/endpoints.river
@@ -37,7 +37,8 @@ discovery.relabel "metric_annotations" {
       "__meta_kubernetes_endpoints_label_metrics_agent_grafana_com_service_monitor",
     ]
     separator = ";"
-    regex = "^(?:;*)?(true|false).*$"
+    // only allow empty or true, otherwise defaults to false
+    regex = "^(?:;*)?(true)(;|true)*$"
     replacement = "$1"
     target_label = "__tmp_scrape"
   }

--- a/modules/kubernetes/metrics/relabelings/annotations/metrics/endpoints.river
+++ b/modules/kubernetes/metrics/relabelings/annotations/metrics/endpoints.river
@@ -14,6 +14,11 @@ discovery.relabel "metric_annotations" {
   //   metrics.agent.grafana.com/scrape: false
   // or
   //   prometheus.io/scrape: true
+  //
+  // the label prometheus.io/service-monitor: "false" is a common label for headless services, when performing endpoint
+  // service discovery, if there is both a load-balanced service and headless service, this can result in duplicate
+  // scrapes if the name of the service is attached as a label.  any targets with this label or annotation set should be dropped
+
   rule {
     action = "replace"
     replacement = "false"
@@ -26,6 +31,10 @@ discovery.relabel "metric_annotations" {
       "__meta_kubernetes_endpoints_annotation_metrics_agent_grafana_com_scrape",
       "__meta_kubernetes_service_annotation_prometheus_io_scrape",
       "__meta_kubernetes_endpoints_annotation_prometheus_io_scrape",
+      "__meta_kubernetes_service_label_prometheus_io_service_monitor",
+      "__meta_kubernetes_endpoints_label_prometheus_io_service_monitor",
+      "__meta_kubernetes_service_label_metrics_agent_grafana_com_service_monitor",
+      "__meta_kubernetes_endpoints_label_metrics_agent_grafana_com_service_monitor",
     ]
     separator = ";"
     regex = "^(?:;*)?(true|false).*$"

--- a/modules/kubernetes/metrics/relabelings/auto-scrape.river
+++ b/modules/kubernetes/metrics/relabelings/auto-scrape.river
@@ -56,15 +56,4 @@ prometheus.relabel "auto_scrape" {
     target_label = "instance"
   }
 
-  // if a collected metric contains a label that is already set i.e. "namespace", it will be changed to "exported_namespace"
-  // to avoid a collision, but this is not desirable for most cases.  move these back and drop and labels that start with
-  // exported_
-  rule {
-    action = "labelmap"
-    regex = "exported_(.+)"
-  }
-  rule {
-    action = "labeldrop"
-    regex = "exported_(.+)"
-  }
 }

--- a/modules/kubernetes/metrics/relabelings/auto-scrape.river
+++ b/modules/kubernetes/metrics/relabelings/auto-scrape.river
@@ -56,4 +56,15 @@ prometheus.relabel "auto_scrape" {
     target_label = "instance"
   }
 
+  // if a collected metric contains a label that is already set i.e. "namespace", it will be changed to "exported_namespace"
+  // to avoid a collision, but this is not desirable for most cases.  move these back and drop and labels that start with
+  // exported_
+  rule {
+    action = "labelmap"
+    regex = "exported_(.+)"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "exported_(.+)"
+  }
 }

--- a/modules/kubernetes/metrics/relabelings/auto-scrape.river
+++ b/modules/kubernetes/metrics/relabelings/auto-scrape.river
@@ -1,0 +1,59 @@
+/*
+Module: relabelings-auto-scrape
+Description: Handles metric relabelings for collected metrics from auto-scraped targets via annotations
+*/
+argument "forward_to" {
+  // comment = "The module to forward the output to"
+  optional = false
+}
+
+argument "job_label" {
+  optional = true
+  default = "auto-scrape"
+  // comment = "The default job label to add"
+}
+
+export "metric_relabelings" {
+  value = prometheus.relabel.auto_scrape
+}
+
+prometheus.relabel "auto_scrape" {
+  forward_to = argument.forward_to.value
+
+  // set the job label, only if job is not specified or contains "module.", the value of the annotation
+  // metrics.agent.grafana.com/job or prometheus.io/job takes precedence
+  rule {
+    action = "replace"
+    source_labels = ["job"]
+    separator = ";"
+    regex = "(?i)^(.*module\\..*|)$"
+    replacement = argument.job_label.value
+    target_label = "job"
+  }
+
+  // set the job label, only if job is the default job_label and the label app.kubernetes.io/name exists
+  // on the service, endpoint or pod, set the value to ${namespace}/${name}
+  rule {
+    action = "replace"
+    source_labels = [
+      "job",
+      "namespace",
+      "app",
+    ]
+    separator = ";"
+    regex = "^" + argument.job_label.value + ";([^;]+);(.+)$"
+    replacement = "$1/$2"
+    target_label = "job"
+  }
+
+  // set the instance label to the name of the pod that was scraped, there are many dashboards and rules that rely on the
+  // instance label being present as it is automatically assigned to the scraped target if not set.  However, we don't
+  // want to create high-cardinality unnecessairly, so it does not make sense to have it be the worker node the pod is on.
+  rule {
+    action = "replace"
+    source_labels = ["pod"]
+    regex = "(.+)"
+    target_label = "instance"
+  }
+
+}

--- a/modules/kubernetes/metrics/relabelings/kube-state-metrics.river
+++ b/modules/kubernetes/metrics/relabelings/kube-state-metrics.river
@@ -36,6 +36,28 @@ export "metric_relabelings" {
 prometheus.relabel "kube_state_metrics" {
   forward_to = argument.forward_to.value
 
+  // kube-state-metrics typically expects the following labels to be present:
+  // - exported_namespace
+  // - exported_instance
+  // - exported_pod
+  // - exported_container
+  //
+  // to be present, the exported_ is a prefix added when there are label collisions, meaning the metrics returned
+  // have labels that already exist.  This all works, except for container, if using Service Discovery endpoint/pod
+  // and the pod has multiple containers that expose ports this can result in potentially duplicate scrape jobs,
+  // which would lead to duplicate metrics.  The configuration is to typically not keep a "container" label, as it
+  // can cause duplicate scrapes and incorrect metric calculations for instances where a pod has multiple containers
+  // and multiple ports even if a single port should be scraped.  However, for opencost dashboards/rules to work correctly,
+  // this should be added, since it is not auto-generated and the container label returned from opencost is just "container"
+  // we need to copy it
+  rule {
+    action = "replace"
+    source_labels = ["container"]
+    regex = "(.+)"
+    replacement = "$1"
+    target_label = "exported_container"
+  }
+
   // due to the fact it is easier to perform a keep and maintain a whitelist, we have to take a
   // multi-step approach since the metrics could be coming from any job, not just kube-state-metrics:
   //

--- a/modules/kubernetes/metrics/relabelings/opencost.river
+++ b/modules/kubernetes/metrics/relabelings/opencost.river
@@ -34,7 +34,7 @@ export "metric_relabelings" {
 prometheus.relabel "opencost" {
   forward_to = argument.forward_to.value
 
-  // opencost typically expects theeeee following labels to be present:
+  // opencost typically expects the following labels to be present:
   // - exported_namespace
   // - exported_instance
   // - exported_pod

--- a/modules/kubernetes/metrics/relabelings/opencost.river
+++ b/modules/kubernetes/metrics/relabelings/opencost.river
@@ -56,6 +56,21 @@ prometheus.relabel "opencost" {
     target_label = "exported_container"
   }
 
+  // opencost looks for an "app" label for dashboard population, based on the values from the metric kube_pod_labels
+  // so there is something consistent, copy the first value from each of the following labels, and assign it to "app"
+  rule {
+    action = "replace"
+    source_labels = [
+      "app",
+      "label_app_kubernetes_io_name",
+      "label_k8s_app",
+    ]
+    separator = ";"
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "app"
+  }
+
   // due to the fact it is easier to perform a keep and maintain a whitelist, we have to take a
   // multi-step approach since the metrics could be coming from any job, not just opencost:
   //

--- a/modules/kubernetes/metrics/relabelings/opencost.river
+++ b/modules/kubernetes/metrics/relabelings/opencost.river
@@ -23,7 +23,7 @@ argument "pod_name" {
 
 argument "keep_metrics" {
   optional = true
-  default = ".*"
+  default = "(.*)"
   // comment = "Regex of metrics to keep"
 }
 

--- a/modules/kubernetes/metrics/relabelings/opencost.river
+++ b/modules/kubernetes/metrics/relabelings/opencost.river
@@ -23,8 +23,6 @@ argument "pod_name" {
 
 argument "keep_metrics" {
   optional = true
-  // from Grafana Cloud Integration: kubelet_running_containers|go_goroutines|kubelet_runtime_operations_errors_total|cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits|namespace_memory:kube_pod_container_resource_limits:sum|kubelet_volume_stats_inodes_used|kubelet_certificate_manager_server_ttl_seconds|namespace_workload_pod:kube_pod_owner:relabel|kubelet_node_config_error|kube_daemonset_status_number_misscheduled|kube_pod_container_resource_requests|namespace_cpu:kube_pod_container_resource_limits:sum|container_memory_working_set_bytes|container_fs_reads_bytes_total|kube_node_status_condition|namespace_cpu:kube_pod_container_resource_requests:sum|kubelet_server_expiration_renew_errors|container_fs_writes_total|kube_horizontalpodautoscaler_status_desired_replicas|node_filesystem_avail_bytes|kube_pod_status_reason|node_filesystem_size_bytes|kube_deployment_spec_replicas|kube_statefulset_metadata_generation|namespace_workload_pod|storage_operation_duration_seconds_count|kubelet_certificate_manager_client_expiration_renew_errors|kube_pod_container_resource_limits|kube_statefulset_status_replicas_updated|node_namespace_pod_container:container_memory_rss|kube_statefulset_status_observed_generation|node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate|kubelet_pleg_relist_interval_seconds_bucket|kube_job_status_start_time|kube_deployment_status_observed_generation|kubelet_pod_worker_duration_seconds_bucket|container_memory_cache|kube_resourcequota|kube_horizontalpodautoscaler_spec_min_replicas|namespace_memory:kube_pod_container_resource_requests:sum|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_daemonset_status_number_available|kube_job_failed|storage_operation_errors_total|cluster:namespace:pod_memory:active:kube_pod_container_resource_limits|container_fs_writes_bytes_total|kube_statefulset_replicas|kube_replicaset_owner|container_network_receive_bytes_total|volume_manager_total_volumes|kube_horizontalpodautoscaler_spec_max_replicas|kube_daemonset_status_desired_number_scheduled|kube_pod_container_status_waiting_reason|process_cpu_seconds_total|kube_node_status_allocatable|kube_deployment_status_replicas_available|kube_daemonset_status_updated_number_scheduled|container_network_receive_packets_total|container_memory_rss|container_cpu_usage_seconds_total|kube_namespace_status_phase|cluster:namespace:pod_memory:active:kube_pod_container_resource_requests|kubelet_volume_stats_available_bytes|kube_deployment_status_replicas_updated|kubelet_running_container_count|kube_node_info|container_network_transmit_packets_dropped_total|kubelet_certificate_manager_client_ttl_seconds|kube_pod_owner|kubelet_volume_stats_inodes|kubelet_runtime_operations_total|container_cpu_cfs_throttled_periods_total|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_running_pod_count|container_network_transmit_packets_total|kubelet_node_name|kube_daemonset_status_current_number_scheduled|kube_statefulset_status_replicas_ready|cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests|kubelet_volume_stats_capacity_bytes|kube_horizontalpodautoscaler_status_current_replicas|node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile|kube_node_spec_taint|kubelet_pleg_relist_duration_seconds_bucket|kube_pod_status_phase|container_cpu_cfs_periods_total|kube_deployment_metadata_generation|node_namespace_pod_container:container_memory_cache|kube_statefulset_status_current_revision|kubelet_pleg_relist_duration_seconds_count|container_fs_reads_total|kube_statefulset_status_update_revision|container_network_receive_packets_dropped_total|kube_pod_info|kubelet_running_pods|process_resident_memory_bytes|kubelet_pod_worker_duration_seconds_count|kubelet_pod_start_duration_seconds_count|kubelet_cgroup_manager_duration_seconds_count|kube_node_status_capacity|container_network_transmit_bytes_total|rest_client_requests_total|kubernetes_build_info|machine_memory_bytes|kube_statefulset_status_replicas|container_memory_swap|kube_job_status_active|kubelet_pod_start_duration_seconds_bucket|node_namespace_pod_container:container_memory_working_set_bytes|node_namespace_pod_container:container_memory_swap|kube_namespace_status_phase|container_cpu_usage_seconds_total|kube_pod_status_phase|kube_pod_start_time|kube_pod_container_status_restarts_total|kube_pod_container_info|kube_pod_container_status_waiting_reason|kube_daemonset.*|kube_replicaset.*|kube_statefulset.*|kube_job.*|kube_node.*|node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate|cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests|namespace_cpu:kube_pod_container_resource_requests:sum|node_cpu.*|node_memory.*|node_filesystem.*|node_network_transmit_bytes_total
-  // the default is the same, however any values with a ":" were removed as those are the result of recording rules and actually output by opencost, and are sorted alphabetically
   default = ".*"
   // comment = "Regex of metrics to keep"
 }
@@ -33,8 +31,30 @@ export "metric_relabelings" {
   value = prometheus.relabel.kube_state_metrics
 }
 
-prometheus.relabel "kube_state_metrics" {
+prometheus.relabel "opencost" {
   forward_to = argument.forward_to.value
+
+  // opencost typically expects theeeee following labels to be present:
+  // - exported_namespace
+  // - exported_instance
+  // - exported_pod
+  // - exported_container
+  //
+  // to be present, the exported_ is a prefix added when there are label collisions, meaning the metrics returned
+  // have labels that already exist.  This all works, except for container, if using Service Discovery endpoint/pod
+  // and the pod has multiple containers that expose ports this can result in potentially duplicate scrape jobs,
+  // which would lead to duplicate metrics.  The configuration is to typically not keep a "container" label, as it
+  // can cause duplicate scrapes and incorrect metric calculations for instances where a pod has multiple containers
+  // and multiple ports even if a single port should be scraped.  However, for opencost dashboards/rules to work correctly,
+  // this should be added, since it is not auto-generated and the container label returned from opencost is just "container"
+  // we need to copy it
+  rule {
+    action = "replace"
+    source_labels = ["container"]
+    regex = "(.+)"
+    replacement = "$1"
+    target_label = "exported_container"
+  }
 
   // due to the fact it is easier to perform a keep and maintain a whitelist, we have to take a
   // multi-step approach since the metrics could be coming from any job, not just opencost:

--- a/modules/kubernetes/metrics/relabelings/opencost.river
+++ b/modules/kubernetes/metrics/relabelings/opencost.river
@@ -61,14 +61,15 @@ prometheus.relabel "opencost" {
   rule {
     action = "replace"
     source_labels = [
-      "app",
+      "__name__",
+      "label_app",
       "label_app_kubernetes_io_name",
       "label_k8s_app",
     ]
     separator = ";"
-    regex = "^(?:;*)?([^;]+).*$"
+    regex = "^kube_pod_labels;(?:;*)?([^;]+).*$"
     replacement = "$1"
-    target_label = "app"
+    target_label = "label_app"
   }
 
   // due to the fact it is easier to perform a keep and maintain a whitelist, we have to take a

--- a/modules/kubernetes/metrics/relabelings/opencost.river
+++ b/modules/kubernetes/metrics/relabelings/opencost.river
@@ -61,13 +61,13 @@ prometheus.relabel "opencost" {
   rule {
     action = "replace"
     source_labels = [
-      "__name__",
+      "pod",
       "label_app",
       "label_app_kubernetes_io_name",
       "label_k8s_app",
     ]
     separator = ";"
-    regex = "^kube_pod_labels;(?:;*)?([^;]+).*$"
+    regex = "^.*" + argument.pod_name.value + ".*;(?:;*)?([^;]+).*$"
     replacement = "$1"
     target_label = "label_app"
   }

--- a/modules/kubernetes/metrics/relabelings/opencost.river
+++ b/modules/kubernetes/metrics/relabelings/opencost.river
@@ -28,7 +28,7 @@ argument "keep_metrics" {
 }
 
 export "metric_relabelings" {
-  value = prometheus.relabel.kube_state_metrics
+  value = prometheus.relabel.opencost
 }
 
 prometheus.relabel "opencost" {

--- a/modules/kubernetes/metrics/scrapes/auto-scrape-endpoints.river
+++ b/modules/kubernetes/metrics/scrapes/auto-scrape-endpoints.river
@@ -142,21 +142,30 @@ prometheus.relabel "endpoints" {
     target_label = "job"
   }
 
-  // remove the instance label from everything, except when the controller type is a daemonset
-  rule {
-    action = "labeldrop"
-    regex = "instance"
-  }
-
+  // set the job label, only if job is "kubernetes-endpoint-scrape" and the label app.kubernetes.io/name exists
+  // on the service, endpoint or pod, set the value to ${namespace}/${name}
   rule {
     action = "replace"
     source_labels = [
-      "__meta_kubernetes_pod_controller_kind",
-      "__meta_kubernetes_pod_node_name",
+      "job",
+      "__meta_kubernetes_namespace",
+      "__meta_kubernetes_service_label_app_kubernetes_io_name",
+      "__meta_kubernetes_endpoints_label_app_kubernetes_io_name",
+      "__meta_kubernetes_pod_label_app_kubernetes_io_name",
     ]
     separator = ";"
-    regex = "DaemonSet;(.+)"
-    replacement = "$1"
+    regex = "^(?i)kubernetes-endpoint-scrape;([^;]+);(?:;*)?([^;]+).*$"
+    replacement = "$1/$2"
+    target_label = "job"
+  }
+
+  // set the instance label to the name of the pod that was scraped, there are many dashboards and rules that rely on the
+  // instance label being present as it is automatically assigned to the scraped target if not set.  However, we don't
+  // want to create high-cardinality unnecessairly, so it does not make sense to have it be the worker node the pod is on.
+  rule {
+    action = "replace"
+    source_labels = ["pod"]
+    regex = "(.+)"
     target_label = "instance"
   }
 }

--- a/modules/kubernetes/metrics/scrapes/auto-scrape-endpoints.river
+++ b/modules/kubernetes/metrics/scrapes/auto-scrape-endpoints.river
@@ -149,12 +149,10 @@ prometheus.relabel "endpoints" {
     source_labels = [
       "job",
       "__meta_kubernetes_namespace",
-      "__meta_kubernetes_service_label_app_kubernetes_io_name",
-      "__meta_kubernetes_endpoints_label_app_kubernetes_io_name",
-      "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+      "app",
     ]
     separator = ";"
-    regex = "^(?i)kubernetes-endpoint-scrape;([^;]+);(?:;*)?([^;]+).*$"
+    regex = "^kubernetes-endpoint-scrape;([^;]+);(.+)$"
     replacement = "$1/$2"
     target_label = "job"
   }

--- a/modules/kubernetes/metrics/scrapes/auto-scrape-endpoints.river
+++ b/modules/kubernetes/metrics/scrapes/auto-scrape-endpoints.river
@@ -124,6 +124,17 @@ module.git "relabelings_node_exporter" {
   path = "modules/kubernetes/metrics/relabelings/node-exporter.river"
 
   arguments {
+    forward_to = [module.git.relabelings_opencost.exports.metric_relabelings.receiver]
+  }
+}
+
+module.git "relabelings_opencost" {
+  repository = argument.git_repo.value
+  revision = argument.git_rev.value
+  pull_frequency = argument.git_pull_freq.value
+  path = "modules/kubernetes/metrics/relabelings/opencost.river"
+
+  arguments {
     forward_to = [module.git.relabelings_auto_scrape.exports.metric_relabelings.receiver]
   }
 }

--- a/modules/kubernetes/metrics/scrapes/auto-scrape-endpoints.river
+++ b/modules/kubernetes/metrics/scrapes/auto-scrape-endpoints.river
@@ -152,7 +152,7 @@ prometheus.relabel "endpoints" {
       "app",
     ]
     separator = ";"
-    regex = "^kubernetes-endpoint-scrape;([^;]+);(.+)$"
+    regex = "^(.*module\\.[^;]*|);([^;]+);(.+)$"
     replacement = "$1/$2"
     target_label = "job"
   }

--- a/modules/kubernetes/metrics/scrapes/auto-scrape-endpoints.river
+++ b/modules/kubernetes/metrics/scrapes/auto-scrape-endpoints.river
@@ -124,46 +124,19 @@ module.git "relabelings_node_exporter" {
   path = "modules/kubernetes/metrics/relabelings/node-exporter.river"
 
   arguments {
-    forward_to = [prometheus.relabel.endpoints.receiver]
+    forward_to = [module.git.relabelings_auto_scrape.exports.metric_relabelings.receiver]
   }
 }
 
-prometheus.relabel "endpoints" {
-  forward_to = argument.forward_to.value
+// metric relabelings
+module.git "relabelings_auto_scrape" {
+  repository = argument.git_repo.value
+  revision = argument.git_rev.value
+  pull_frequency = argument.git_pull_freq.value
+  path = "modules/kubernetes/metrics/relabelings/auto-scrape.river"
 
-  // set the job label, only if job is not specified or contains "module.", the value of the annotation
-  // metrics.agent.grafana.com/job takes precedence
-  rule {
-    action = "replace"
-    source_labels = ["job"]
-    separator = ";"
-    regex = "(?i)^(.*module\\..*|)$"
-    replacement = "kubernetes-endpoint-scrape"
-    target_label = "job"
-  }
-
-  // set the job label, only if job is "kubernetes-endpoint-scrape" and the label app.kubernetes.io/name exists
-  // on the service, endpoint or pod, set the value to ${namespace}/${name}
-  rule {
-    action = "replace"
-    source_labels = [
-      "job",
-      "__meta_kubernetes_namespace",
-      "app",
-    ]
-    separator = ";"
-    regex = "^(.*module\\.[^;]*|);([^;]+);(.+)$"
-    replacement = "$1/$2"
-    target_label = "job"
-  }
-
-  // set the instance label to the name of the pod that was scraped, there are many dashboards and rules that rely on the
-  // instance label being present as it is automatically assigned to the scraped target if not set.  However, we don't
-  // want to create high-cardinality unnecessairly, so it does not make sense to have it be the worker node the pod is on.
-  rule {
-    action = "replace"
-    source_labels = ["pod"]
-    regex = "(.+)"
-    target_label = "instance"
+  arguments {
+    forward_to = argument.forward_to.value
+    job_label = "kubernetes-endpoint-auto-scrape"
   }
 }

--- a/modules/kubernetes/metrics/scrapes/auto-scrape-pods.river
+++ b/modules/kubernetes/metrics/scrapes/auto-scrape-pods.river
@@ -99,49 +99,22 @@ module.git "pod_targets" {
 
 prometheus.scrape "scrape_pods" {
   targets = module.git.pod_targets.exports.relabelings.output
-  forward_to = [prometheus.relabel.pods.receiver]
+  forward_to = [module.git.relabelings_auto_scrape.exports.metric_relabelings.receiver]
 
   clustering {
     enabled = argument.clustering.value
   }
 }
 
-prometheus.relabel "pods" {
-  forward_to = argument.forward_to.value
+// metric relabelings
+module.git "relabelings_auto_scrape" {
+  repository = argument.git_repo.value
+  revision = argument.git_rev.value
+  pull_frequency = argument.git_pull_freq.value
+  path = "modules/kubernetes/metrics/relabelings/auto-scrape.river"
 
-  // set the job label, only if job is not specified or contains "module.", the value of the annotation
-  // metrics.agent.grafana.com/job takes precedence
-  rule {
-    action = "replace"
-    source_labels = ["job"]
-    separator = ";"
-    regex = "(?i)^(.*module\\..*|)$"
-    replacement = "kubernetes-pod-scrape"
-    target_label = "job"
-  }
-
-  // set the job label, only if job is "kubernetes-pod-scrape" and the label app.kubernetes.io/name exists
-  // on the service, endpoint or pod, set the value to ${namespace}/${name}
-  rule {
-    action = "replace"
-    source_labels = [
-      "job",
-      "__meta_kubernetes_namespace",
-      "app",
-    ]
-    separator = ";"
-    regex = "^(.*module\\.[^;]*|);([^;]+);(.+)$"
-    replacement = "$1/$2"
-    target_label = "job"
-  }
-
-  // set the instance label to the name of the pod that was scraped, there are many dashboards and rules that rely on the
-  // instance label being present as it is automatically assigned to the scraped target if not set.  However, we don't
-  // want to create high-cardinality unnecessairly, so it does not make sense to have it be the worker node the pod is on.
-  rule {
-    action = "replace"
-    source_labels = ["pod"]
-    regex = "(.+)"
-    target_label = "instance"
+  arguments {
+    forward_to = argument.forward_to.value
+    job_label = "kubernetes-pod-auto-scrape"
   }
 }

--- a/modules/kubernetes/metrics/scrapes/auto-scrape-pods.river
+++ b/modules/kubernetes/metrics/scrapes/auto-scrape-pods.river
@@ -130,7 +130,7 @@ prometheus.relabel "pods" {
       "app",
     ]
     separator = ";"
-    regex = "^kubernetes-endpoint-scrape;([^;]+);(.+)$"
+    regex = "^(.*module\\.[^;]*|);([^;]+);(.+)$"
     replacement = "$1/$2"
     target_label = "job"
   }

--- a/modules/kubernetes/metrics/scrapes/auto-scrape-pods.river
+++ b/modules/kubernetes/metrics/scrapes/auto-scrape-pods.river
@@ -127,10 +127,10 @@ prometheus.relabel "pods" {
     source_labels = [
       "job",
       "__meta_kubernetes_namespace",
-      "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+      "app",
     ]
     separator = ";"
-    regex = "^(?i)kubernetes-pod-scrape;([^;]+);(?:;*)?([^;]+).*$"
+    regex = "^kubernetes-endpoint-scrape;([^;]+);(.+)$"
     replacement = "$1/$2"
     target_label = "job"
   }

--- a/modules/kubernetes/metrics/scrapes/auto-scrape-pods.river
+++ b/modules/kubernetes/metrics/scrapes/auto-scrape-pods.river
@@ -120,21 +120,28 @@ prometheus.relabel "pods" {
     target_label = "job"
   }
 
-  // remove the instance label from everything, except when the controller type is a daemonset
-  rule {
-    action = "labeldrop"
-    regex = "instance"
-  }
-
+  // set the job label, only if job is "kubernetes-pod-scrape" and the label app.kubernetes.io/name exists
+  // on the service, endpoint or pod, set the value to ${namespace}/${name}
   rule {
     action = "replace"
     source_labels = [
-      "__meta_kubernetes_pod_controller_kind",
-      "__meta_kubernetes_pod_node_name",
+      "job",
+      "__meta_kubernetes_namespace",
+      "__meta_kubernetes_pod_label_app_kubernetes_io_name",
     ]
     separator = ";"
-    regex = "DaemonSet;(.+)"
-    replacement = "$1"
+    regex = "^(?i)kubernetes-pod-scrape;([^;]+);(?:;*)?([^;]+).*$"
+    replacement = "$1/$2"
+    target_label = "job"
+  }
+
+  // set the instance label to the name of the pod that was scraped, there are many dashboards and rules that rely on the
+  // instance label being present as it is automatically assigned to the scraped target if not set.  However, we don't
+  // want to create high-cardinality unnecessairly, so it does not make sense to have it be the worker node the pod is on.
+  rule {
+    action = "replace"
+    source_labels = ["pod"]
+    regex = "(.+)"
     target_label = "instance"
   }
 }

--- a/modules/kubernetes/metrics/scrapes/kube-dns.river
+++ b/modules/kubernetes/metrics/scrapes/kube-dns.river
@@ -3,6 +3,11 @@ Module: scrape-kube-dns
 Description: Scrapes Kube dns, most of these same metrics can come from cAdvisor use only if necessary.  If using annotations
              then this module does not need to be used as the kube-dns pods most likely already have the annotation
              prometheus.io/scrape: true set
+
+             !!Note!!
+             This module most likely does not need to be included, if you're using the auto-scrape-pods.river module, as
+             most kube-dns pods have the annotation prometheus.io/scrape: "true" set already on the pods but not the services.
+
 */
 argument "forward_to" {
   // comment = "Where to send the results to"

--- a/modules/kubernetes/metrics/targets/endpoints.river
+++ b/modules/kubernetes/metrics/targets/endpoints.river
@@ -61,6 +61,11 @@ discovery.relabel "scrape_targets" {
     source_labels = ["__meta_kubernetes_pod_phase"]
     regex = "^(?i)(Running|)$"
   }
+  rule {
+    action = "keep"
+    source_labels = ["__meta_kubernetes_pod_ready"]
+    regex = "true"
+  }
 
   // add a __tmp_scrape_port_named_metrics
   rule {
@@ -184,6 +189,14 @@ module.git "relabelings_service" {
 
 discovery.relabel "pod_labels" {
   targets = module.git.relabelings_service.exports.relabelings.output
+
+  // if the container is an init container, drop it
+  rule {
+    action = "drop"
+    source_labels = ["__meta_kubernetes_pod_container_init"]
+    regex = "true"
+  }
+
   // as this can result in duplicate scrapes of the same target because the labels are different
   // drop the container label
   rule {

--- a/modules/kubernetes/metrics/targets/endpoints.river
+++ b/modules/kubernetes/metrics/targets/endpoints.river
@@ -190,4 +190,18 @@ discovery.relabel "pod_labels" {
     action = "labeldrop"
     regex = "container"
   }
+
+  // add a label for the port that is being scraped, separately from the the instance / __address__,
+  // only if there is not a port label defined already
+  rule {
+    action = "replace"
+    source_labels = [
+      "port",
+      "__address__",
+    ]
+    separator = ";"
+    regex = "^;[^;:]+:(\\d+)"
+    replacement = "$1"
+    target_label = "port"
+  }
 }

--- a/modules/kubernetes/metrics/targets/pods.river
+++ b/modules/kubernetes/metrics/targets/pods.river
@@ -159,4 +159,18 @@ discovery.relabel "pod_labels" {
     action = "labeldrop"
     regex = "container"
   }
+
+  // add a label for the port that is being scraped, separately from the the instance / __address__,
+  // only if there is not a port label defined already
+  rule {
+    action = "replace"
+    source_labels = [
+      "port",
+      "__address__",
+    ]
+    separator = ";"
+    regex = "^;[^;:]+:(\\d+)"
+    replacement = "$1"
+    target_label = "port"
+  }
 }

--- a/modules/kubernetes/metrics/targets/pods.river
+++ b/modules/kubernetes/metrics/targets/pods.river
@@ -55,6 +55,11 @@ discovery.relabel "scrape_targets" {
     source_labels = ["__meta_kubernetes_pod_phase"]
     regex = "^(?i)(Running|)$"
   }
+  rule {
+    action = "keep"
+    source_labels = ["__meta_kubernetes_pod_ready"]
+    regex = "true"
+  }
 
   // only keep endpoint targets that have scrape: true
   rule {
@@ -153,6 +158,14 @@ module.git "relabelings_pod" {
 
 discovery.relabel "pod_labels" {
   targets = module.git.relabelings_pod.exports.relabelings.output
+
+  // if the container is an init container, drop it
+  rule {
+    action = "drop"
+    source_labels = ["__meta_kubernetes_pod_container_init"]
+    regex = "true"
+  }
+
   // as this can result in duplicate scrapes of the same target because the labels are different
   // drop the container label
   rule {

--- a/modules/kubernetes/relabelings/endpoints.river
+++ b/modules/kubernetes/relabelings/endpoints.river
@@ -22,4 +22,25 @@ discovery.relabel "endpoints" {
     target_label = "endpoints_name"
   }
 
+  // the endpoints name
+  rule {
+    action = "replace"
+    source_labels = ["__meta_kubernetes_endpoints_name"]
+    target_label = "endpoints_name"
+  }
+
+  // set whether or not the service the endpoint is attached to is headless, by checking for the exist of a label:
+  // service.kubernetes.io/headless: ""
+  rule {
+    action = "replace"
+    replacement = "false"
+    target_label = "__tmp_headless"
+  }
+  rule {
+    action = "replace"
+    source_labels = ["__meta_kubernetes_endpoints_labelpresent_service_kubernetes_io_headless"]
+    regex = "^(true)$"
+    replacement = "$1"
+    target_label = "__tmp_headless"
+  }
 }

--- a/modules/kubernetes/relabelings/pod.river
+++ b/modules/kubernetes/relabelings/pod.river
@@ -57,7 +57,7 @@ discovery.relabel "pods" {
       "__meta_kubernetes_pod_name",
     ]
     action = "replace"
-    regex = "^(ReplicaSet);(.*)(-[^-]+)(-[^-]{5})$"
+    regex = "^(ReplicaSet);(.*)(-[^-]+)(-[^-]{5})?$"
     replacement = "$1/$2"
     target_label = "deployment"
   }

--- a/modules/kubernetes/relabelings/pod.river
+++ b/modules/kubernetes/relabelings/pod.river
@@ -57,7 +57,7 @@ discovery.relabel "pods" {
       "__meta_kubernetes_pod_name",
     ]
     action = "replace"
-    regex = "^(ReplicaSet);(.*)(-[^-]+)(-[^-]{5})?$"
+    regex = "^(ReplicaSet);(.*)(-[a-f0-9]+)(-[a-z0-9]+)?$"
     replacement = "$1/$2"
     target_label = "deployment"
   }

--- a/modules/kubernetes/relabelings/pod.river
+++ b/modules/kubernetes/relabelings/pod.river
@@ -96,7 +96,7 @@ discovery.relabel "pods" {
     ]
     action = "replace"
     regex = "^;(.+)$"
-    replacement = "Pod/$2"
+    replacement = "Pod/$1"
     target_label = "deployment"
   }
 

--- a/modules/kubernetes/relabelings/service.river
+++ b/modules/kubernetes/relabelings/service.river
@@ -22,4 +22,21 @@ discovery.relabel "service" {
     target_label = "service"
   }
 
+  // set whether or not the service is headless, by checking for the exist of a label:
+  // service.kubernetes.io/headless: ""
+  rule {
+    action = "replace"
+    replacement = "false"
+    target_label = "__tmp_headless"
+  }
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_service_labelpresent_service_kubernetes_io_headless",
+      "__meta_kubernetes_endpoints_labelpresent_service_kubernetes_io_headless",
+    ]
+    regex = "^(?:;*)?(true).*$"
+    replacement = "$1"
+    target_label = "__tmp_headless"
+  }
 }


### PR DESCRIPTION
- Honor label of `prometheus.io/service-monitor: false` and drop targets, this label is set by Mimir/Loki helm charts.  this was leading to duplicate scrape jobs
- Set a __tmp_headless variable that can be used based on the existence of `service.kubernetes.io/headless: ""`
- Updated `logs.agent.grafana.com/log-format: ` annotation to support multiple log formats, as a single pod could have multiple containers of different formats
- `logs.agent.grafana.com/log-format:` annotations now do a loose check to see if the line matches the expected pattern before parsing
- Updated the label handling for the generated `deployment="ReplicaSet/..." to handle different formats
- Set a job label based on `namespace/app` if defined. 
- `kube-dns` is scrapped automatically via annotations
- Don't auto-scrape endpoints and pods, only scrape one or the other as this can lead to duplicate jobs when the annotations are added to both the service and the pod
- Drop targets from InitContainers and pods that aren't ready
- Ensure `exported_container` label is set for kube-state-metrics and opencast scrape jobs. 
- Added syslog format