### PR TITLE
JSON Exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center"><img src="assets/logo_and_name.png" alt="Grafana Agent logo"></p>
 
-[Modules](https://grafana.com/docs/agent/latest/flow/concepts/modules/) are a 
+[Modules](https://grafana.com/docs/agent/latest/flow/concepts/modules/) are a
 way to create Grafana Agent [Flow](https://grafana.com/docs/agent/latest/flow/)
 configurations which can be loaded as a component. Modules are a great way to
 parameterize a configuration to create reusable pipelines.
@@ -12,8 +12,9 @@ parameterize a configuration to create reusable pipelines.
 
 ## Modules
 
-| Name |  Description | Agent Version | 
-| ---- |  ----------- | ------------- | 
+| Name |  Description | Agent Version |
+| ---- |  ----------- | ------------- |
+| [Metrics and Logs Annotation Ingestion](./modules/kubernetes/) | Module to ingest Metrics (scraping/probes) and Logs through annotations. | `>= v0.36.1`
 | [OTLP to LGTM](./modules/otlp/otlp-to-lgtm/) | Module to ingest OTLP data and then send it to Loki, Mimir and Tempo stacks locally or in GrafanaCloud. | `>= v0.33`
 | [Grafana Agent Telemetry to LGTM](./modules/grafana-agent/telemetry-to-lgtm/) | Module to forward the Grafana Agent's own telemetry data to Loki, Mimir and Tempo stacks locally or in Grafana Cloud. | `>= v0.33`
 | [Grafana Agent Dynamic Blackbox Exporter](./modules/grafana-agent/dynamic-blackbox/) | Module to use blackbox exporter with dynamic targets. | `>= v0.35`
@@ -34,4 +35,3 @@ Modules must contain the following elements:
 * Arguments
 * Exports
 * The body of the module
-

--- a/example/kubernetes/logs/simple-events.river
+++ b/example/kubernetes/logs/simple-events.river
@@ -7,7 +7,7 @@ logging {
 }
 
 module.git "event_logs" {
-  repository = "https://github.com/bentonam/agent-modules.git"
+  repository = "https://github.com/grafana/agent-modules.git"
   revision   = "main"
   path       = "modules/kubernetes/logs/events.river"
 

--- a/example/kubernetes/metrics/json-exporter.river
+++ b/example/kubernetes/metrics/json-exporter.river
@@ -25,6 +25,9 @@ module.git "metrics_primary" {
 The json exporter modules are not included in the default all.river, as it is not as common.  Include the json-services and/or json-ingress module,
 and set the forward_to to be the exporter writer from the all.river module or declare a new instance of the prometheus.remote_write component.
 Ensure JSON Exporter is installed in the cluster and the json_exporter_url is set to the service name and port of the json exporter.
+
+Docs: https://github.com/prometheus-community/json_exporter/tree/master
+Helm Chart: https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-json-exporter
 */
 
 module.git "json_services" {

--- a/example/kubernetes/metrics/json-exporter.river
+++ b/example/kubernetes/metrics/json-exporter.river
@@ -1,0 +1,50 @@
+/*
+The following example shows using the default all metrics processing module, for
+a single tenant and specifying the destination url/credentials via environment
+variables.
+*/
+logging {
+  level  = coalesce(env("AGENT_LOG_LEVEL"), "info")
+  format = "logfmt"
+}
+
+module.git "metrics_primary" {
+  repository = "https://github.com/grafana/agent-modules.git"
+  revision   = "main"
+  path       = "modules/kubernetes/metrics/all.river"
+
+  arguments {
+    mimir_url = env("DEFAULT_METRICS_URL")
+    mimir_username = env("DEFAULT_METRICS_TENANT")
+    mimir_password = env("DEFAULT_METRICS_TOKEN")
+    blackbox_url = "blackbox-prometheus-blackbox-exporter.agents.svc.cluster.local:9115"
+  }
+}
+
+/*
+The json exporter modules are not included in the default all.river, as it is not as common.  Include the json-services and/or json-ingress module,
+and set the forward_to to be the exporter writer from the all.river module or declare a new instance of the prometheus.remote_write component.
+Ensure JSON Exporter is installed in the cluster and the json_exporter_url is set to the service name and port of the json exporter.
+*/
+
+module.git "json_services" {
+  repository = "https://github.com/grafana/agent-modules.git"
+  revision   = "main"
+  path = "modules/kubernetes/metrics/scrapes/json-services.river"
+
+  arguments {
+    forward_to = [module.git.metrics_primary.exports.prometheus_remote.receiver]
+    json_exporter_url = "json-exporter.agents.svc.cluster.local:7979"
+  }
+}
+
+module.git "json_ingresses" {
+  repository = "https://github.com/grafana/agent-modules.git"
+  revision   = "main"
+  path = "modules/kubernetes/metrics/scrapes/json-ingresses.river"
+
+  arguments {
+    forward_to = [module.git.metrics_primary.exports.prometheus_remote.receiver]
+    json_exporter_url = "json-exporter.agents.svc.cluster.local:7979"
+  }
+}

--- a/modules/kubernetes/README.md
+++ b/modules/kubernetes/README.md
@@ -40,6 +40,8 @@ The following pod annotations are supported are supported for gathering of metri
 | `metrics.agent.grafana.com/interval` <br> `prometheus.io/interval` | The default interval to scrape is `1m`, this can be specified as a single value which would override, the scrape interval being used for all ports attached to the endpoint / pod. |
 | `metrics.agent.grafana.com/timeout` <br> `prometheus.io/timeout` | The default timeout for scraping is `10s`, this can be specified as a single value which would override, the scrape interval being used for all ports attached to the endpoint / pod. |
 
+### Probes (Blackbox)
+
 The following service / ingress annotations are supported are supported for probes and the gathering of metrics from blackbox exporter:
 
 | Annotation       | Description |
@@ -52,5 +54,20 @@ The following service / ingress annotations are supported are supported for prob
 | `probes.agent.grafana.com/job` | The job label value to use when collecting their metrics, this can be useful as service / ingress will be automatically probed for metrics, separate jobs do not have to be defined.  However, it is common to use an integration or community project where rules / dashboards are provided for you.  Oftentimes, this provided assets use hard-coded values for a job label i.e. `...{job="blackbox-exporter"...}` setting this annotation to that value will allow the provided asset to work out of the box. |
 | `probes.agent.grafana.com/interval` | The default interval to probe is `1m`, this can be specified as a single value which would override, the probe interval being used for all ports attached to the service / ingress. |
 | `probes.agent.grafana.com/timeout` | The default timeout for scraping is `10s`, this can be specified as a single value which would override, the probe interval being used for all ports attached to the service / ingress. |
+
+### Probes (json-exporter)
+
+The following service / ingress annotations are supported are supported for probes and the gathering of metrics from json-exporter exporter:
+
+| Annotation       | Description |
+| :--------------- | :-----------|
+| `json.agent.grafana.com/probe` | Boolean whether or not to probe the service / ingress for metrics. *Note*: If a pod exposes multiple ports, all ports would be probed.  To limit this behavior specify the port annotation to limit the probe to a single port. |
+| `json.agent.grafana.com/port` <br> `prometheus.io/port` | The default port to probe is the service / ingress port, this can be specified as a single value which would override the probe port being used for all ports attached to the service / ingress, note that even if aan service / ingress had multiple targets, the relabel_config targets are deduped before scraping |
+| `json.agent.grafana.com/path` | The default path to probe is `/metrics`, this can be specified as a single value which would override, the probe path being used for all ports attached to the service / ingress. |
+| `json.agent.grafana.com/module` | The name of the json-exporter module to use for probing the resource, the default value is "unknown" as these values should be determined from your json-exporter-exporter configuration file. |
+| `json.agent.grafana.com/tenant` | The tenant their metrics should be sent to, this does not necessarily have to be the actual tenantId, it can be a friendly name as well that is simply used to determine if the metrics should be gathered for the current tenant |
+| `json.agent.grafana.com/job` | The job label value to use when collecting their metrics, this can be useful as service / ingress will be automatically probed for metrics, separate jobs do not have to be defined.  However, it is common to use an integration or community project where rules / dashboards are provided for you.  Oftentimes, this provided assets use hard-coded values for a job label i.e. `...{job="json-exporter"...}` setting this annotation to that value will allow the provided asset to work out of the box. |
+| `json.agent.grafana.com/interval` | The default interval to probe is `1m`, this can be specified as a single value which would override, the probe interval being used for all ports attached to the service / ingress. |
+| `json.agent.grafana.com/timeout` | The default timeout for scraping is `10s`, this can be specified as a single value which would override, the probe interval being used for all ports attached to the service / ingress. |
 
 See [/example/kubernetes/metrics](../../example/kubernetes/metrics/) for working example configurations.

--- a/modules/kubernetes/logs/all.river
+++ b/modules/kubernetes/logs/all.river
@@ -81,13 +81,8 @@ argument "git_pull_freq" {
   default = "5m"
 }
 
-argument "remote" {
-  comment = "The loki remote to use for the module, if not specified one is created"
-  optional = true
-}
-
 export "loki_remote" {
-  value = coalesce(argument.remote.value, loki.write.destination)
+  value = loki.write.destination
 }
 
 module.git "log_targets" {
@@ -201,7 +196,7 @@ module.git "label_keep" {
   path = "modules/kubernetes/logs/labels/keep-labels.river"
 
   arguments {
-    forward_to = coalesce(argument.remote.value, loki.write.destination).receiver
+    forward_to = loki.write.destination.receiver
     keep_labels = argument.keep_labels.value
   }
 }

--- a/modules/kubernetes/logs/all.river
+++ b/modules/kubernetes/logs/all.river
@@ -81,6 +81,15 @@ argument "git_pull_freq" {
   default = "5m"
 }
 
+argument "remote" {
+  comment = "The loki remote to use for the module, if not specified one is created"
+  optional = true
+}
+
+export "loki_remote" {
+  value = coalesce(argument.remote.value, loki.write.destination)
+}
+
 module.git "log_targets" {
   repository = argument.git_repo.value
   revision = argument.git_rev.value
@@ -192,7 +201,7 @@ module.git "label_keep" {
   path = "modules/kubernetes/logs/labels/keep-labels.river"
 
   arguments {
-    forward_to = loki.write.destination.receiver
+    forward_to = coalesce(argument.remote.value, loki.write.destination).receiver
     keep_labels = argument.keep_labels.value
   }
 }

--- a/modules/kubernetes/logs/events.river
+++ b/modules/kubernetes/logs/events.river
@@ -96,6 +96,15 @@ argument "git_pull_freq" {
   default = "5m"
 }
 
+argument "remote" {
+  comment = "The loki remote to use for the module, if not specified one is created"
+  optional = true
+}
+
+export "loki_remote" {
+  value = coalesce(argument.remote.value, loki.write.destination)
+}
+
 loki.source.kubernetes_events "events" {
   job_name = argument.label_job.value
   namespaces = argument.namespaces.value
@@ -233,7 +242,7 @@ module.git "label_keep" {
   path = "modules/kubernetes/logs/labels/keep-labels.river"
 
   arguments {
-    forward_to = loki.write.destination.receiver
+    forward_to = coalesce(argument.remote.value, loki.write.destination).receiver
     keep_labels = argument.keep_labels.value
   }
 }

--- a/modules/kubernetes/logs/events.river
+++ b/modules/kubernetes/logs/events.river
@@ -96,13 +96,8 @@ argument "git_pull_freq" {
   default = "5m"
 }
 
-argument "remote" {
-  comment = "The loki remote to use for the module, if not specified one is created"
-  optional = true
-}
-
 export "loki_remote" {
-  value = coalesce(argument.remote.value, loki.write.destination)
+  value = loki.write.destination
 }
 
 loki.source.kubernetes_events "events" {
@@ -242,7 +237,7 @@ module.git "label_keep" {
   path = "modules/kubernetes/logs/labels/keep-labels.river"
 
   arguments {
-    forward_to = coalesce(argument.remote.value, loki.write.destination).receiver
+    forward_to = loki.write.destination.receiver
     keep_labels = argument.keep_labels.value
   }
 }

--- a/modules/kubernetes/logs/kubelet.river
+++ b/modules/kubernetes/logs/kubelet.river
@@ -112,13 +112,8 @@ argument "git_pull_freq" {
   default = "5m"
 }
 
-argument "remote" {
-  comment = "The loki remote to use for the module, if not specified one is created"
-  optional = true
-}
-
 export "loki_remote" {
-  value = coalesce(argument.remote.value, loki.write.destination)
+  value = loki.write.destination
 }
 
 loki.relabel "journal" {
@@ -268,7 +263,7 @@ module.git "label_keep" {
   path = "modules/kubernetes/logs/labels/keep-labels.river"
 
   arguments {
-    forward_to = coalesce(argument.remote.value, loki.write.destination).receiver
+    forward_to = loki.write.destination.receiver
     keep_labels = argument.keep_labels.value
   }
 }

--- a/modules/kubernetes/logs/kubelet.river
+++ b/modules/kubernetes/logs/kubelet.river
@@ -112,6 +112,15 @@ argument "git_pull_freq" {
   default = "5m"
 }
 
+argument "remote" {
+  comment = "The loki remote to use for the module, if not specified one is created"
+  optional = true
+}
+
+export "loki_remote" {
+  value = coalesce(argument.remote.value, loki.write.destination)
+}
+
 loki.relabel "journal" {
   forward_to = []
 
@@ -259,7 +268,7 @@ module.git "label_keep" {
   path = "modules/kubernetes/logs/labels/keep-labels.river"
 
   arguments {
-    forward_to = loki.write.destination.receiver
+    forward_to = coalesce(argument.remote.value, loki.write.destination).receiver
     keep_labels = argument.keep_labels.value
   }
 }

--- a/modules/kubernetes/metrics/all.river
+++ b/modules/kubernetes/metrics/all.river
@@ -201,40 +201,6 @@ module.git "probe_ingresses" {
   }
 }
 
-module.git "json_services" {
-  repository = argument.git_repo.value
-  revision = argument.git_rev.value
-  pull_frequency = argument.git_pull_freq.value
-  path = "modules/kubernetes/metrics/scrapes/json-services.river"
-
-  arguments {
-    forward_to = [prometheus.remote_write.destination.receiver]
-    tenant = argument.tenant.value
-    clustering = argument.clustering.value
-    json_exporter_url = argument.json_exporter_url.value
-    git_repo = argument.git_repo.value
-    git_rev = argument.git_rev.value
-    git_pull_freq = argument.git_pull_freq.value
-  }
-}
-
-module.git "json_ingresses" {
-  repository = argument.git_repo.value
-  revision = argument.git_rev.value
-  pull_frequency = argument.git_pull_freq.value
-  path = "modules/kubernetes/metrics/scrapes/json-ingresses.river"
-
-  arguments {
-    forward_to = [prometheus.remote_write.destination.receiver]
-    tenant = argument.tenant.value
-    clustering = argument.clustering.value
-    json_exporter_url = argument.json_exporter_url.value
-    git_repo = argument.git_repo.value
-    git_rev = argument.git_rev.value
-    git_pull_freq = argument.git_pull_freq.value
-  }
-}
-
 prometheus.remote_write "destination" {
   endpoint {
     url = argument.mimir_url.value

--- a/modules/kubernetes/metrics/all.river
+++ b/modules/kubernetes/metrics/all.river
@@ -55,6 +55,12 @@ argument "blackbox_url" {
   default = ""
 }
 
+argument "json_exporter_url" {
+  // comment = "The address of the json exporter to use (without the protocol), only the hostname and port i.e. json-prometheus-json-exporter.default.svc.cluster.local:9115"
+  optional = true
+  default = ""
+}
+
 argument "tenant" {
   // comment = "The tenant to filter logs to.  This does not have to be the tenantId, this is the value to look for in the logs.agent.grafana.com/tenant annotation, and this can be a regex."
   optional = true
@@ -210,7 +216,7 @@ module.git "json_services" {
     forward_to = [coalesce(argument.remote.value, prometheus.remote_write.destination).receiver]
     tenant = argument.tenant.value
     clustering = argument.clustering.value
-    blackbox_url = argument.blackbox_url.value
+    json_exporter_url = argument.json_exporter_url.value
     git_repo = argument.git_repo.value
     git_rev = argument.git_rev.value
     git_pull_freq = argument.git_pull_freq.value
@@ -227,7 +233,7 @@ module.git "json_ingresses" {
     forward_to = [coalesce(argument.remote.value, prometheus.remote_write.destination).receiver]
     tenant = argument.tenant.value
     clustering = argument.clustering.value
-    blackbox_url = argument.blackbox_url.value
+    json_exporter_url = argument.json_exporter_url.value
     git_repo = argument.git_repo.value
     git_rev = argument.git_rev.value
     git_pull_freq = argument.git_pull_freq.value

--- a/modules/kubernetes/metrics/all.river
+++ b/modules/kubernetes/metrics/all.river
@@ -82,13 +82,8 @@ argument "git_pull_freq" {
   default = "5m"
 }
 
-argument "remote" {
-  comment = "The prometheus remote to use for the module, if not specified one is created"
-  optional = true
-}
-
 export "prometheus_remote" {
-  value = coalesce(argument.remote.value, prometheus.remote_write.destination)
+  value = prometheus.remote_write.destination
 }
 
 module.git "scrape_kubelet_cadvisor" {
@@ -98,7 +93,7 @@ module.git "scrape_kubelet_cadvisor" {
   path = "modules/kubernetes/metrics/scrapes/kubelet-cadvisor.river"
 
   arguments {
-    forward_to = [coalesce(argument.remote.value, prometheus.remote_write.destination).receiver]
+    forward_to = [prometheus.remote_write.destination.receiver]
     tenant = argument.tenant.value
     clustering = argument.clustering.value
     git_repo = argument.git_repo.value
@@ -114,7 +109,7 @@ module.git "scrape_kubelet" {
   path = "modules/kubernetes/metrics/scrapes/kubelet.river"
 
   arguments {
-    forward_to = [coalesce(argument.remote.value, prometheus.remote_write.destination).receiver]
+    forward_to = [prometheus.remote_write.destination.receiver]
     tenant = argument.tenant.value
     clustering = argument.clustering.value
     git_repo = argument.git_repo.value
@@ -130,7 +125,7 @@ module.git "scrape_kubelet_probes" {
   path = "modules/kubernetes/metrics/scrapes/kubelet-probes.river"
 
   arguments {
-    forward_to = [coalesce(argument.remote.value, prometheus.remote_write.destination).receiver]
+    forward_to = [prometheus.remote_write.destination.receiver]
     tenant = argument.tenant.value
     clustering = argument.clustering.value
     git_repo = argument.git_repo.value
@@ -146,7 +141,7 @@ module.git "scrape_kube_apiserver" {
   path = "modules/kubernetes/metrics/scrapes/kube-apiserver.river"
 
   arguments {
-    forward_to = [coalesce(argument.remote.value, prometheus.remote_write.destination).receiver]
+    forward_to = [prometheus.remote_write.destination.receiver]
     tenant = argument.tenant.value
     clustering = argument.clustering.value
     git_repo = argument.git_repo.value
@@ -162,7 +157,7 @@ module.git "scrape_endpoints" {
   path = "modules/kubernetes/metrics/scrapes/auto-scrape-endpoints.river"
 
   arguments {
-    forward_to = [coalesce(argument.remote.value, prometheus.remote_write.destination).receiver]
+    forward_to = [prometheus.remote_write.destination.receiver]
     tenant = argument.tenant.value
     clustering = argument.clustering.value
     scrape_port_named_metrics = argument.scrape_port_named_metrics.value
@@ -179,7 +174,7 @@ module.git "probe_services" {
   path = "modules/kubernetes/metrics/scrapes/auto-probe-services.river"
 
   arguments {
-    forward_to = [coalesce(argument.remote.value, prometheus.remote_write.destination).receiver]
+    forward_to = [prometheus.remote_write.destination.receiver]
     tenant = argument.tenant.value
     clustering = argument.clustering.value
     blackbox_url = argument.blackbox_url.value
@@ -196,7 +191,7 @@ module.git "probe_ingresses" {
   path = "modules/kubernetes/metrics/scrapes/auto-probe-ingresses.river"
 
   arguments {
-    forward_to = [coalesce(argument.remote.value, prometheus.remote_write.destination).receiver]
+    forward_to = [prometheus.remote_write.destination.receiver]
     tenant = argument.tenant.value
     clustering = argument.clustering.value
     blackbox_url = argument.blackbox_url.value
@@ -213,7 +208,7 @@ module.git "json_services" {
   path = "modules/kubernetes/metrics/scrapes/json-services.river"
 
   arguments {
-    forward_to = [coalesce(argument.remote.value, prometheus.remote_write.destination).receiver]
+    forward_to = [prometheus.remote_write.destination.receiver]
     tenant = argument.tenant.value
     clustering = argument.clustering.value
     json_exporter_url = argument.json_exporter_url.value
@@ -230,7 +225,7 @@ module.git "json_ingresses" {
   path = "modules/kubernetes/metrics/scrapes/json-ingresses.river"
 
   arguments {
-    forward_to = [coalesce(argument.remote.value, prometheus.remote_write.destination).receiver]
+    forward_to = [prometheus.remote_write.destination.receiver]
     tenant = argument.tenant.value
     clustering = argument.clustering.value
     json_exporter_url = argument.json_exporter_url.value

--- a/modules/kubernetes/metrics/all.river
+++ b/modules/kubernetes/metrics/all.river
@@ -181,6 +181,40 @@ module.git "probe_ingresses" {
   path = "modules/kubernetes/metrics/scrapes/auto-probe-ingresses.river"
 
   arguments {
+    forward_to = [coalesce(argument.remote.value, prometheus.remote_write.destination).receiver]
+    tenant = argument.tenant.value
+    clustering = argument.clustering.value
+    blackbox_url = argument.blackbox_url.value
+    git_repo = argument.git_repo.value
+    git_rev = argument.git_rev.value
+    git_pull_freq = argument.git_pull_freq.value
+  }
+}
+
+module.git "json_services" {
+  repository = argument.git_repo.value
+  revision = argument.git_rev.value
+  pull_frequency = argument.git_pull_freq.value
+  path = "modules/kubernetes/metrics/scrapes/json-services.river"
+
+  arguments {
+    forward_to = [prometheus.remote_write.destination.receiver]
+    tenant = argument.tenant.value
+    clustering = argument.clustering.value
+    blackbox_url = argument.blackbox_url.value
+    git_repo = argument.git_repo.value
+    git_rev = argument.git_rev.value
+    git_pull_freq = argument.git_pull_freq.value
+  }
+}
+
+module.git "json_ingresses" {
+  repository = argument.git_repo.value
+  revision = argument.git_rev.value
+  pull_frequency = argument.git_pull_freq.value
+  path = "modules/kubernetes/metrics/scrapes/json-ingresses.river"
+
+  arguments {
     forward_to = [prometheus.remote_write.destination.receiver]
     tenant = argument.tenant.value
     clustering = argument.clustering.value

--- a/modules/kubernetes/metrics/all.river
+++ b/modules/kubernetes/metrics/all.river
@@ -76,6 +76,15 @@ argument "git_pull_freq" {
   default = "5m"
 }
 
+argument "remote" {
+  comment = "The prometheus remote to use for the module, if not specified one is created"
+  optional = true
+}
+
+export "prometheus_remote" {
+  value = coalesce(argument.remote.value, prometheus.remote_write.destination)
+}
+
 module.git "scrape_kubelet_cadvisor" {
   repository = argument.git_repo.value
   revision = argument.git_rev.value
@@ -83,7 +92,7 @@ module.git "scrape_kubelet_cadvisor" {
   path = "modules/kubernetes/metrics/scrapes/kubelet-cadvisor.river"
 
   arguments {
-    forward_to = [prometheus.remote_write.destination.receiver]
+    forward_to = [coalesce(argument.remote.value, prometheus.remote_write.destination).receiver]
     tenant = argument.tenant.value
     clustering = argument.clustering.value
     git_repo = argument.git_repo.value
@@ -99,7 +108,7 @@ module.git "scrape_kubelet" {
   path = "modules/kubernetes/metrics/scrapes/kubelet.river"
 
   arguments {
-    forward_to = [prometheus.remote_write.destination.receiver]
+    forward_to = [coalesce(argument.remote.value, prometheus.remote_write.destination).receiver]
     tenant = argument.tenant.value
     clustering = argument.clustering.value
     git_repo = argument.git_repo.value
@@ -115,7 +124,7 @@ module.git "scrape_kubelet_probes" {
   path = "modules/kubernetes/metrics/scrapes/kubelet-probes.river"
 
   arguments {
-    forward_to = [prometheus.remote_write.destination.receiver]
+    forward_to = [coalesce(argument.remote.value, prometheus.remote_write.destination).receiver]
     tenant = argument.tenant.value
     clustering = argument.clustering.value
     git_repo = argument.git_repo.value
@@ -131,7 +140,7 @@ module.git "scrape_kube_apiserver" {
   path = "modules/kubernetes/metrics/scrapes/kube-apiserver.river"
 
   arguments {
-    forward_to = [prometheus.remote_write.destination.receiver]
+    forward_to = [coalesce(argument.remote.value, prometheus.remote_write.destination).receiver]
     tenant = argument.tenant.value
     clustering = argument.clustering.value
     git_repo = argument.git_repo.value
@@ -147,7 +156,7 @@ module.git "scrape_endpoints" {
   path = "modules/kubernetes/metrics/scrapes/auto-scrape-endpoints.river"
 
   arguments {
-    forward_to = [prometheus.remote_write.destination.receiver]
+    forward_to = [coalesce(argument.remote.value, prometheus.remote_write.destination).receiver]
     tenant = argument.tenant.value
     clustering = argument.clustering.value
     scrape_port_named_metrics = argument.scrape_port_named_metrics.value
@@ -164,7 +173,7 @@ module.git "probe_services" {
   path = "modules/kubernetes/metrics/scrapes/auto-probe-services.river"
 
   arguments {
-    forward_to = [prometheus.remote_write.destination.receiver]
+    forward_to = [coalesce(argument.remote.value, prometheus.remote_write.destination).receiver]
     tenant = argument.tenant.value
     clustering = argument.clustering.value
     blackbox_url = argument.blackbox_url.value
@@ -198,7 +207,7 @@ module.git "json_services" {
   path = "modules/kubernetes/metrics/scrapes/json-services.river"
 
   arguments {
-    forward_to = [prometheus.remote_write.destination.receiver]
+    forward_to = [coalesce(argument.remote.value, prometheus.remote_write.destination).receiver]
     tenant = argument.tenant.value
     clustering = argument.clustering.value
     blackbox_url = argument.blackbox_url.value
@@ -215,7 +224,7 @@ module.git "json_ingresses" {
   path = "modules/kubernetes/metrics/scrapes/json-ingresses.river"
 
   arguments {
-    forward_to = [prometheus.remote_write.destination.receiver]
+    forward_to = [coalesce(argument.remote.value, prometheus.remote_write.destination).receiver]
     tenant = argument.tenant.value
     clustering = argument.clustering.value
     blackbox_url = argument.blackbox_url.value

--- a/modules/kubernetes/metrics/relabelings/annotations/json/ingress.river
+++ b/modules/kubernetes/metrics/relabelings/annotations/json/ingress.river
@@ -1,0 +1,205 @@
+argument "targets" {
+  // comment = "Discovered targets to apply relabelings to"
+  optional = false
+}
+
+export "relabelings" {
+  value = discovery.relabel.probe_annotations
+}
+
+discovery.relabel "probe_annotations" {
+  targets = argument.targets.value
+
+  // allow resources to declare they should be probed or not, the following annotations are supported:
+  //   json.agent.grafana.com/probe: false
+  // or
+  //   prometheus.io/probe: true
+  rule {
+    action = "replace"
+    replacement = "false"
+    target_label = "__tmp_probe"
+  }
+  rule {
+    action = "replace"
+    source_labels = ["__meta_kubernetes_ingress_annotation_json_agent_grafana_com_probe"]
+    separator = ";"
+    regex = "^(?:;*)?(true|false).*$"
+    replacement = "$1"
+    target_label = "__tmp_probe"
+  }
+  // only keep service targets that have probe: true, the following annotations are supported:
+  rule {
+    action = "keep"
+    source_labels = ["__tmp_probe"]
+    regex = "true"
+  }
+
+  // allow resources to declare the port to use when probing, the default value is the discovered port from
+  // service discovery, the following annotations are supported:
+  //   json.agent.grafana.com/port: 9090
+  // fallback
+  //   metrics.agent.grafana.com/port: 9090
+  // or
+  //   prometheus.io/port: 9090
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_ingress_annotation_json_agent_grafana_com_port",
+      "__meta_kubernetes_ingress_annotation_metrics_agent_grafana_com_port",
+      "__meta_kubernetes_ingress_annotation_prometheus_io_port",
+    ]
+    separator = ";"
+    regex = "^(?:;*)?(\\d+).*$"
+    replacement = "$1"
+    target_label = "__tmp_probe_port"
+  }
+
+  // allow resources to declare their the path to use when being probed, the default value is "/metrics",
+  // the following annotations are supported:
+  //   json.agent.grafana.com/path: /~/ready
+  rule {
+    action = "replace"
+    replacement = "/metrics"
+    target_label = "__tmp_probe_path"
+  }
+  rule {
+    action = "replace"
+    source_labels = ["__meta_kubernetes_ingress_annotation_json_agent_grafana_com_path"]
+    separator = ";"
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "__tmp_probe_path"
+  }
+
+  // allow resources to declare the tenant to send probe metrics to should be sent to, the following annotation is supported:
+  //   json.agent.grafana.com/tenant: primary
+  // fallback
+  //   metrics.agent.grafana.com/tenant: primary
+  //
+  // Note: This does not necessarily have to be the actual tenantId, it can be a friendly name as well that is simply used
+  //       to determine if the metrics should be gathered for the current tenant
+  rule {
+    action = "replace"
+    replacement = ""
+    target_label = "__tmp_probe_tenant"
+  }
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_ingress_annotation_json_agent_grafana_com_tenant",
+      "__meta_kubernetes_ingress_annotation_metrics_agent_grafana_com_tenant",
+    ]
+    separator = ";"
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "__tmp_probe_tenant"
+  }
+
+  // allow resources to declare the protocol to use when probing, the default value is "",
+  // this is the protocol that is used when sending the request to blackbox exporter, it is NOT
+  // the protocol used.  For ingresses, if the annotation is not specified default to the scheme
+  // defined for the ingress as it can only be http/https
+  // the following the following annotations are supported:
+  //   json.agent.grafana.com/scheme: http
+  rule {
+    action = "replace"
+    replacement = ""
+    target_label = "__tmp_probe_scheme"
+  }
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_ingress_annotation_json_agent_grafana_com_scheme",
+      "__meta_kubernetes_ingress_scheme",
+    ]
+    separator = ";"
+    regex = "^(?:;*)?(https?).*$"
+    replacement = "$1://"
+    target_label = "__tmp_probe_scheme"
+  }
+
+  // allow resources to declare their the module to use when probing, the default value is "unknown",
+  // the following annotations are supported:
+  //   json.agent.grafana.com/module: my-app
+  rule {
+    action = "replace"
+    replacement = "unknown"
+    target_label = "__tmp_probe_module"
+  }
+  rule {
+    action = "replace"
+    source_labels = ["__meta_kubernetes_ingress_annotation_json_agent_grafana_com_module"]
+    separator = ";"
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "__tmp_probe_module"
+  }
+
+  // allow resources to declare how often they should be probed, the default value is 1m,
+  // the following annotations are supporte with the value provided in duration format:
+  //   json.agent.grafana.com/interval: 5m
+  // fallback
+  //   metrics.agent.grafana.com/interval: 5m
+  // fallback
+  //   prometheus.io/interval: 5m
+  rule {
+    action = "replace"
+    replacement = "1m"
+    target_label = "__tmp_probe_interval"
+  }
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_ingress_annotation_json_agent_grafana_com_interval",
+      "__meta_kubernetes_ingress_annotation_metrics_agent_grafana_com_interval",
+      "__meta_kubernetes_ingress_annotation_prometheus_io_interval",
+    ]
+    separator = ";"
+    regex = "^(?:;*)?(\\d+(s|m|ms|h|d)).*$"
+    replacement = "$1"
+    target_label = "__tmp_probe_interval"
+  }
+
+  // allow resources to declare the timeout of the scrape request, the default value is 10s,
+  // the following annotations are supporte with the value provided in duration format:
+  //   json.agent.grafana.com/timeout: 30s
+  // fallback
+  //   metrics.agent.grafana.com/timeout: 30s
+  // fallback
+  //   prometheus.io/timeout: 30s
+  rule {
+    action = "replace"
+    replacement = "1m"
+    target_label = "__tmp_probe_timeout"
+  }
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_ingress_annotation_json_agent_grafana_com_timeout",
+      "__meta_kubernetes_ingress_annotation_metrics_agent_grafana_com_timeout",
+      "__meta_kubernetes_ingress_annotation_prometheus_io_timeout",
+    ]
+    separator = ";"
+    regex = "^(?:;*)?(\\d+(s|m|ms|h|d)).*$"
+    replacement = "$1"
+    target_label = "__tmp_probe_timeout"
+  }
+
+  // allow resources to declare their the job label value to use probing, the default value is "blackbox-exporter",
+  // the following annotations are supported:
+  //   json.agent.grafana.com/job: my-service-probe
+  rule {
+    action = "replace"
+    replacement = ""
+    target_label = "__tmp_job"
+  }
+  rule {
+    action = "replace"
+    source_labels = ["__meta_kubernetes_ingress_annotation_json_agent_grafana_com_job"]
+    separator = ";"
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "__tmp_probe_job"
+  }
+
+}

--- a/modules/kubernetes/metrics/relabelings/annotations/json/service.river
+++ b/modules/kubernetes/metrics/relabelings/annotations/json/service.river
@@ -1,0 +1,200 @@
+argument "targets" {
+  // comment = "Discovered targets to apply relabelings to"
+  optional = false
+}
+
+export "relabelings" {
+  value = discovery.relabel.json_annotations
+}
+
+discovery.relabel "json_annotations" {
+  targets = argument.targets.value
+
+  // allow resources to declare they should be probed or not, the following annotations are supported:
+  //   json.agent.grafana.com/probe: false
+  // or
+  //   prometheus.io/probe: true
+  rule {
+    action = "replace"
+    replacement = "false"
+    target_label = "__tmp_probe"
+  }
+  rule {
+    action = "replace"
+    source_labels = ["__meta_kubernetes_service_annotation_json_agent_grafana_com_probe"]
+    separator = ";"
+    regex = "^(?:;*)?(true|false).*$"
+    replacement = "$1"
+    target_label = "__tmp_probe"
+  }
+  // only keep service targets that have probe: true, the following annotations are supported:
+  rule {
+    action = "keep"
+    source_labels = ["__tmp_probe"]
+    regex = "true"
+  }
+
+  // allow resources to declare the port to use when probing, the default value is the discovered port from
+  // service discovery, the following annotations are supported:
+  //   json.agent.grafana.com/port: 9090
+  // fallback
+  //   metrics.agent.grafana.com/port: 9090
+  // or
+  //   prometheus.io/port: 9090
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_service_annotation_json_agent_grafana_com_port",
+      "__meta_kubernetes_service_annotation_metrics_agent_grafana_com_port",
+      "__meta_kubernetes_service_annotation_prometheus_io_port",
+    ]
+    separator = ";"
+    regex = "^(?:;*)?(\\d+).*$"
+    replacement = "$1"
+    target_label = "__tmp_probe_port"
+  }
+
+  // allow resources to declare their the path to use when being probed, the default value is "/metrics",
+  // the following annotations are supported:
+  //   json.agent.grafana.com/path: /~/ready
+  rule {
+    action = "replace"
+    replacement = "/metrics"
+    target_label = "__tmp_probe_path"
+  }
+  rule {
+    action = "replace"
+    source_labels = ["__meta_kubernetes_service_annotation_json_agent_grafana_com_path"]
+    separator = ";"
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "__tmp_probe_path"
+  }
+
+  // allow resources to declare the tenant to send probe metrics to should be sent to, the following annotation is supported:
+  //   json.agent.grafana.com/tenant: primary
+  // fallback
+  //   metrics.agent.grafana.com/tenant: primary
+  //
+  // Note: This does not necessarily have to be the actual tenantId, it can be a friendly name as well that is simply used
+  //       to determine if the metrics should be gathered for the current tenant
+  rule {
+    action = "replace"
+    replacement = ""
+    target_label = "__tmp_probe_tenant"
+  }
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_service_annotation_json_agent_grafana_com_tenant",
+      "__meta_kubernetes_service_annotation_metrics_agent_grafana_com_tenant",
+    ]
+    separator = ";"
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "__tmp_probe_tenant"
+  }
+
+  // allow resources to declare the protocol to use when probing, the default value is "",
+  // this is the protocol that is used when sending the request to blackbox exporter, it is NOT
+  // the protocol used.
+  //   json.agent.grafana.com/scheme: http
+  rule {
+    action = "replace"
+    replacement = ""
+    target_label = "__tmp_probe_scheme"
+  }
+  rule {
+    action = "replace"
+    source_labels = ["__meta_kubernetes_service_annotation_json_agent_grafana_com_scheme"]
+    separator = ";"
+    regex = "^(https?)$"
+    replacement = "$1://"
+    target_label = "__tmp_probe_scheme"
+  }
+
+  // allow resources to declare their the module to use when probing, the default value is "unknown",
+  // the following annotations are supported:
+  //   json.agent.grafana.com/module: my-app
+  rule {
+    action = "replace"
+    replacement = "unknown"
+    target_label = "__tmp_probe_module"
+  }
+  rule {
+    action = "replace"
+    source_labels = ["__meta_kubernetes_service_annotation_json_agent_grafana_com_module"]
+    separator = ";"
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "__tmp_probe_module"
+  }
+
+  // allow resources to declare how often they should be probed, the default value is 1m,
+  // the following annotations are supporte with the value provided in duration format:
+  //   json.agent.grafana.com/interval: 5m
+  // fallback
+  //   metrics.agent.grafana.com/interval: 5m
+  // fallback
+  //   prometheus.io/interval: 5m
+  rule {
+    action = "replace"
+    replacement = "1m"
+    target_label = "__tmp_probe_interval"
+  }
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_service_annotation_json_agent_grafana_com_interval",
+      "__meta_kubernetes_service_annotation_metrics_agent_grafana_com_interval",
+      "__meta_kubernetes_service_annotation_prometheus_io_interval",
+    ]
+    separator = ";"
+    regex = "^(?:;*)?(\\d+(s|m|ms|h|d)).*$"
+    replacement = "$1"
+    target_label = "__tmp_probe_interval"
+  }
+
+  // allow resources to declare the timeout of the scrape request, the default value is 10s,
+  // the following annotations are supporte with the value provided in duration format:
+  //   json.agent.grafana.com/timeout: 30s
+  // fallback
+  //   metrics.agent.grafana.com/timeout: 30s
+  // fallback
+  //   prometheus.io/timeout: 30s
+  rule {
+    action = "replace"
+    replacement = "1m"
+    target_label = "__tmp_probe_timeout"
+  }
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_service_annotation_json_agent_grafana_com_timeout",
+      "__meta_kubernetes_service_annotation_metrics_agent_grafana_com_timeout",
+      "__meta_kubernetes_service_annotation_prometheus_io_timeout",
+    ]
+    separator = ";"
+    regex = "^(?:;*)?(\\d+(s|m|ms|h|d)).*$"
+    replacement = "$1"
+    target_label = "__tmp_probe_timeout"
+  }
+
+  // allow resources to declare their the job label value to use probing, the default value is "blackbox-exporter",
+  // the following annotations are supported:
+  //   json.agent.grafana.com/job: my-service-probe
+  rule {
+    action = "replace"
+    replacement = ""
+    target_label = "__tmp_job"
+  }
+  rule {
+    action = "replace"
+    source_labels = ["__meta_kubernetes_service_annotation_json_agent_grafana_com_job"]
+    separator = ";"
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "__tmp_probe_job"
+  }
+
+}

--- a/modules/kubernetes/metrics/relabelings/json-exporter.river
+++ b/modules/kubernetes/metrics/relabelings/json-exporter.river
@@ -1,0 +1,49 @@
+/*
+Module: relabelings-json
+Description: Handles metric relabelings for collected metrics from json-exporter
+Docs: https://github.com/prometheus-community/json_exporter
+*/
+argument "forward_to" {
+  // comment = "The module to forward the output to"
+  optional = false
+}
+
+argument "job_label" {
+  optional = true
+  // from Grafana Cloud Integration:
+  default = "integrations/json_exporter"
+  // comment = "The job label to add for all blackbox-exporter"
+}
+
+argument "drop_metrics" {
+  optional = true
+  // json does not return that many metrics, however if certain metrics should be dropped they can be specified here
+  // the default is "none" which will not match any of the returned metric names
+  default = "none"
+  // comment = "Regex of metrics to drop"
+}
+
+export "metric_relabelings" {
+  value = prometheus.relabel.json_exporter
+}
+
+prometheus.relabel "json_exporter" {
+  forward_to = argument.forward_to.value
+
+  rule {
+    action = "drop"
+    source_labels = ["__name__"]
+    regex = argument.drop_metrics.value
+  }
+
+  // set the job label, only if job label is not set or contains "module." is not specified, the value of the annotation
+  // probes.agent.grafana.com/job takes precedence
+  rule {
+    action = "replace"
+    source_labels = ["job"]
+    regex = "|.*module\\..*"
+    replacement = argument.job_label.value
+    target_label = "job"
+  }
+
+}

--- a/modules/kubernetes/metrics/scrapes/auto-probe-ingresses.river
+++ b/modules/kubernetes/metrics/scrapes/auto-probe-ingresses.river
@@ -101,7 +101,7 @@ module.git "ingress_targets" {
 
   arguments {
     tenant = argument.tenant.value
-    blackbox_url = argument.blackbox_url.value
+    prober_url = argument.blackbox_url.value
     git_repo = argument.git_repo.value
     git_rev = argument.git_rev.value
     git_pull_freq = argument.git_pull_freq.value

--- a/modules/kubernetes/metrics/scrapes/auto-probe-services.river
+++ b/modules/kubernetes/metrics/scrapes/auto-probe-services.river
@@ -101,7 +101,7 @@ module.git "service_targets" {
 
   arguments {
     tenant = argument.tenant.value
-    blackbox_url = argument.blackbox_url.value
+    prober_url = argument.blackbox_url.value
     git_repo = argument.git_repo.value
     git_rev = argument.git_rev.value
     git_pull_freq = argument.git_pull_freq.value

--- a/modules/kubernetes/metrics/scrapes/json-ingresses.river
+++ b/modules/kubernetes/metrics/scrapes/json-ingresses.river
@@ -1,0 +1,125 @@
+/*
+Module: probe-json-ingresses
+Description:
+  Kubernetes Ingress Auto-Probing for JSON Exporter
+  ------------------------------------------------------------------------------------------------------------------------------------
+  Each port attached to an ingress is an eligible target, oftentimes ingress will have multiple ports.
+  There may be instances when you want to probe all ports or some ports and not others. To support this
+  the following annotations are available:
+
+  only probe ingresses with probe set to true, this can be single valued i.e. probe all ports for
+  the ingress:
+
+  json.agent.grafana.com/probe: true
+
+  the default probing scheme is "", this can be specified as a single value which would override,
+  if using HTTP prober specify "http" or "https":
+
+  json.agent.grafana.com/scheme: https
+
+  the default path to probe is /metrics, this can be specified as a single value which would override,
+  the probe path being used for all ports attached to the ingress:
+
+  json.agent.grafana.com/path: /metrics/some_path
+
+  the default module to use for probing the default value is "unknown" as the modules are defined are in your json exporter
+  configuration file, this can be specified as a single value which would override, the probe module being used for all ports
+  attached to the ingress:
+
+  json.agent.grafana.com/module: my-service
+
+  the default port to probe is the ingress port, this can be specified as a single value which would
+  override the probe port being used for all ports attached to the ingress, note that even if aan ingress had
+  multiple targets, the relabel_config targets are deduped before scraping:
+
+  json.agent.grafana.com/port: 8080
+  prometheus.io/port: 8080
+
+  the value to set for the job label, by default this would be "integrations/json_exporter" if not specified:
+
+  json.agent.grafana.com/job: json-exporter
+
+  the default interval to probe is 1m, this can be specified as a single value which would override,
+  the probe interval being used for all ports attached to the ingress:
+
+  json.agent.grafana.com/interval: 5m
+  prometheus.io/interval: 5m
+
+  the default timeout for scraping is 10s, this can be specified as a single value which would override,
+  the probe interval being used for all ports attached to the ingress:
+
+  json.agent.grafana.com/timeout: 30s
+  prometheus.io/timeout: 30s
+*/
+argument "forward_to" {
+  // comment = "Where to send the results to"
+  optional = false
+}
+
+argument "json_exporter_url" {
+  // comment = "The address of the json exporter to use (without the protocol), only the hostname and port i.e. json-prometheus-json-exporter.default.svc.cluster.local:9115"
+  optional = false
+}
+
+argument "tenant" {
+  // comment = "The tenant to filter logs to.  This does not have to be the tenantId, this is the value to look for in the logs.agent.grafana.com/tenant annotation, and this can be a regex."
+  optional = true
+  default = ".*"
+}
+
+argument "clustering" {
+  // comment = "Whether or not clustering should be enabled"
+  optional = true
+  default = false
+}
+
+argument "git_repo" {
+  optional = true
+  default = coalesce(env("GIT_REPO"), "https://github.com/grafana/agent-modules.git")
+}
+
+argument "git_rev" {
+  optional = true
+  default = coalesce(env("GIT_REV"), env("GIT_REVISION"), env("GIT_BRANCH"), "main")
+}
+
+argument "git_pull_freq" {
+  optional = true
+  default = "5m"
+}
+
+module.git "ingress_targets" {
+  repository = argument.git_repo.value
+  revision = argument.git_rev.value
+  pull_frequency = argument.git_pull_freq.value
+  path = "modules/kubernetes/metrics/targets/ingresses.river"
+
+  arguments {
+    tenant = argument.tenant.value
+    prober_url = argument.json_exporter_url.value
+    git_repo = argument.git_repo.value
+    git_rev = argument.git_rev.value
+    git_pull_freq = argument.git_pull_freq.value
+  }
+}
+
+prometheus.scrape "json_ingresses" {
+  targets = module.git.ingress_targets.exports.relabelings.output
+  forward_to = [module.git.relabelings_json_exporter.exports.metric_relabelings.receiver]
+
+  clustering {
+    enabled = argument.clustering.value
+  }
+}
+
+// metric relabelings
+module.git "relabelings_json_exporter" {
+  repository = argument.git_repo.value
+  revision = argument.git_rev.value
+  pull_frequency = argument.git_pull_freq.value
+  path = "modules/kubernetes/metrics/relabelings/json-exporter.river"
+
+  arguments {
+    forward_to = argument.forward_to.value
+  }
+}

--- a/modules/kubernetes/metrics/scrapes/json-ingresses.river
+++ b/modules/kubernetes/metrics/scrapes/json-ingresses.river
@@ -3,6 +3,9 @@ Module: probe-json-ingresses
 Description:
   Kubernetes Ingress Auto-Probing for JSON Exporter
   ------------------------------------------------------------------------------------------------------------------------------------
+  Docs: https://github.com/prometheus-community/json_exporter/tree/master
+  Helm Chart: https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-json-exporter
+
   Each port attached to an ingress is an eligible target, oftentimes ingress will have multiple ports.
   There may be instances when you want to probe all ports or some ports and not others. To support this
   the following annotations are available:
@@ -57,7 +60,7 @@ argument "forward_to" {
 }
 
 argument "json_exporter_url" {
-  // comment = "The address of the json exporter to use (without the protocol), only the hostname and port i.e. json-prometheus-json-exporter.default.svc.cluster.local:9115"
+  // comment = "The address of the json exporter to use (without the protocol), only the hostname and port i.e. json-exporter.agents.svc.cluster.local:7979"
   optional = false
 }
 

--- a/modules/kubernetes/metrics/scrapes/json-services.river
+++ b/modules/kubernetes/metrics/scrapes/json-services.river
@@ -1,0 +1,125 @@
+/*
+Module: probe-json-services
+Description:
+  Kubernetes Service Auto-Probing for JSON Exporter
+  ------------------------------------------------------------------------------------------------------------------------------------
+  Each port attached to an service is an eligible target, oftentimes service will have multiple ports.
+  There may be instances when you want to probe all ports or some ports and not others. To support this
+  the following annotations are available:
+
+  only probe services with probe set to true, this can be single valued i.e. probe all ports for
+  the service:
+
+  json.agent.grafana.com/probe: true
+
+  the default probing scheme is "", this can be specified as a single value which would override,
+  if using HTTP prober specify "http" or "https":
+
+  json.agent.grafana.com/scheme: https
+
+  the default path to probe is /metrics, this can be specified as a single value which would override,
+  the probe path being used for all ports attached to the service:
+
+  json.agent.grafana.com/path: /metrics/some_path
+
+  the default module to use for json probing is "unknown" as the modules are defined are in your json exporter
+  configuration file, this can be specified as a single value which would override, the probe module being used for all ports
+  attached to the service:
+
+  json.agent.grafana.com/module: my_service
+
+  the default port to probe is the service port, this can be specified as a single value which would
+  override the probe port being used for all ports attached to the service, note that even if aan service had
+  multiple targets, the relabel_config targets are deduped before scraping:
+
+  json.agent.grafana.com/port: 8080
+  prometheus.io/port: 8080
+
+  the value to set for the job label, by default this would be "integrations/json_exporter" if not specified:
+
+  json.agent.grafana.com/job: json-exporter
+
+  the default interval to probe is 1m, this can be specified as a single value which would override,
+  the probe interval being used for all ports attached to the service:
+
+  json.agent.grafana.com/interval: 5m
+  prometheus.io/interval: 5m
+
+  the default timeout for scraping is 10s, this can be specified as a single value which would override,
+  the probe interval being used for all ports attached to the service:
+
+  json.agent.grafana.com/timeout: 30s
+  prometheus.io/timeout: 30s
+*/
+argument "forward_to" {
+  // comment = "Where to send the results to"
+  optional = false
+}
+
+argument "json_exporter_url" {
+  // comment = "The address of the json exporter to use (without the protocol), only the hostname and port i.e. json-prometheus-json-exporter.default.svc.cluster.local:9115"
+  optional = false
+}
+
+argument "tenant" {
+  // comment = "The tenant to filter logs to.  This does not have to be the tenantId, this is the value to look for in the logs.agent.grafana.com/tenant annotation, and this can be a regex."
+  optional = true
+  default = ".*"
+}
+
+argument "clustering" {
+  // comment = "Whether or not clustering should be enabled"
+  optional = true
+  default = false
+}
+
+argument "git_repo" {
+  optional = true
+  default = coalesce(env("GIT_REPO"), "https://github.com/grafana/agent-modules.git")
+}
+
+argument "git_rev" {
+  optional = true
+  default = coalesce(env("GIT_REV"), env("GIT_REVISION"), env("GIT_BRANCH"), "main")
+}
+
+argument "git_pull_freq" {
+  optional = true
+  default = "5m"
+}
+
+module.git "service_targets" {
+  repository = argument.git_repo.value
+  revision = argument.git_rev.value
+  pull_frequency = argument.git_pull_freq.value
+  path = "modules/kubernetes/metrics/targets/services.river"
+
+  arguments {
+    tenant = argument.tenant.value
+    prober_url = argument.json_exporter_url.value
+    git_repo = argument.git_repo.value
+    git_rev = argument.git_rev.value
+    git_pull_freq = argument.git_pull_freq.value
+  }
+}
+
+prometheus.scrape "json_services" {
+  targets = module.git.service_targets.exports.relabelings.output
+  forward_to = [module.git.relabelings_json_exporter.exports.metric_relabelings.receiver]
+
+  clustering {
+    enabled = argument.clustering.value
+  }
+}
+
+// metric relabelings
+module.git "relabelings_json_exporter" {
+  repository = argument.git_repo.value
+  revision = argument.git_rev.value
+  pull_frequency = argument.git_pull_freq.value
+  path = "modules/kubernetes/metrics/relabelings/json-exporter.river"
+
+  arguments {
+    forward_to = argument.forward_to.value
+  }
+}

--- a/modules/kubernetes/metrics/scrapes/json-services.river
+++ b/modules/kubernetes/metrics/scrapes/json-services.river
@@ -3,6 +3,9 @@ Module: probe-json-services
 Description:
   Kubernetes Service Auto-Probing for JSON Exporter
   ------------------------------------------------------------------------------------------------------------------------------------
+  Docs: https://github.com/prometheus-community/json_exporter/tree/master
+  Helm Chart: https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-json-exporter
+
   Each port attached to an service is an eligible target, oftentimes service will have multiple ports.
   There may be instances when you want to probe all ports or some ports and not others. To support this
   the following annotations are available:
@@ -57,7 +60,7 @@ argument "forward_to" {
 }
 
 argument "json_exporter_url" {
-  // comment = "The address of the json exporter to use (without the protocol), only the hostname and port i.e. json-prometheus-json-exporter.default.svc.cluster.local:9115"
+  // comment = "The address of the json exporter to use (without the protocol), only the hostname and port i.e. json-exporter.agents.svc.cluster.local:7979"
   optional = false
 }
 

--- a/modules/kubernetes/metrics/targets/ingresses.river
+++ b/modules/kubernetes/metrics/targets/ingresses.river
@@ -8,8 +8,8 @@ argument "tenant" {
   default = ".*"
 }
 
-argument "blackbox_url" {
-  // comment = "The address of the blackbox exporter to use (without the protocol), only the hostname and port i.e. blackbox-prometheus-blackbox-exporter.default.svc.cluster.local:9115"
+argument "prober_url" {
+  // comment = "The address of the probing exporter (i.e. blackbox, json, snmp) to use (without the protocol), only the hostname and port i.e. blackbox-prometheus-blackbox-exporter.default.svc.cluster.local:9115"
   optional = false
 }
 
@@ -115,10 +115,10 @@ discovery.relabel "probe_targets" {
     target_label = "__metrics_path__"
   }
 
-  // set the __address__ to send the scrape request to be the blackbox exporter ingress address that has been deployed
+  // set the __address__ to send the scrape request to be the probing exporter ingress address that has been deployed
   rule{
     action = "replace"
-    replacement = argument.blackbox_url.value
+    replacement = argument.prober_url.value
     target_label = "__address__"
   }
 

--- a/modules/kubernetes/metrics/targets/services.river
+++ b/modules/kubernetes/metrics/targets/services.river
@@ -8,8 +8,8 @@ argument "tenant" {
   default = ".*"
 }
 
-argument "blackbox_url" {
-  // comment = "The address of the blackbox exporter to use (without the protocol), only the hostname and port i.e. blackbox-prometheus-blackbox-exporter.default.svc.cluster.local:9115"
+argument "prober_url" {
+  // comment = "The address of the probing exporter (i.e. blackbox, json, snmp) to use (without the protocol), only the hostname and port i.e. blackbox-prometheus-blackbox-exporter.default.svc.cluster.local:9115"
   optional = false
 }
 
@@ -115,10 +115,10 @@ discovery.relabel "probe_targets" {
     target_label = "__metrics_path__"
   }
 
-  // set the __address__ to send the scrape request to be the blackbox exporter service address that has been deployed
+  // set the __address__ to send the scrape request to be the probing exporter service address that has been deployed
   rule{
     action = "replace"
-    replacement = argument.blackbox_url.value
+    replacement = argument.prober_url.value
     target_label = "__address__"
   }
 


### PR DESCRIPTION
Added support for JSON Exporter to auto-probe via the following annotations: 

```
json.agent.grafana.com/probe
json.agent.grafana.com/port
json.agent.grafana.com/path
json.agent.grafana.com/module
json.agent.grafana.com/tenant
json.agent.grafana.com/job
json.agent.grafana.com/interval
json.agent.grafana.com/timeout
```

Also updated the following modules to exporter the remote writer: 

- `modules/kubernetes/metrics/all.river`
- `modules/kubernetes/logs/all.river`
- `modules/kubernetes/logs/events.river`
- `modules/kubernetes/logs/kubelet.river`

Updated the following target modules to be more generic for probes instead of specific to blackbox: 

- `modules/kubernetes/metrics/targets/services.river`
- `modules/kubernetes/metrics/targets/ingresses.river`