### PR TITLE
adjustments to propagate keep_metrics argument

### DIFF
--- a/modules/kubernetes/metrics/all.river
+++ b/modules/kubernetes/metrics/all.river
@@ -43,6 +43,26 @@ argument "scrape_port_named_metrics" {
   default = false
 }
 
+argument "keep_ksm_nex_metrics" {
+  // comment = "Regex of metrics to keep, see relabelings/kube-state-metrics.river, relabelings/node-exporter.river for the default value"
+  optional = true
+}
+
+argument "keep_kubelet_metrics" {
+  // comment = "Regex of metrics to keep, see relabelings/kubelet.river for the default value"
+  optional = true
+}
+
+argument "keep_cadvisor_metrics" {
+  // comment = "Regex of metrics to keep, see relabelings/kubelet-cadvisor.river for the default value"
+  optional = true
+}
+
+argument "drop_apiserver_metrics" {
+  // comment = "Regex of metrics to drop, see relabelings/kube-apiserver.river for the default value"
+  optional = true
+}
+
 argument "clustering" {
   // comment = "Whether or not clustering should be enabled"
   optional = true
@@ -97,6 +117,7 @@ module.git "scrape_kubelet_cadvisor" {
   arguments {
     forward_to = [prometheus.remote_write.destination.receiver]
     tenant = argument.tenant.value
+    keep_metrics = argument.keep_cadvisor_metrics.value
     clustering = argument.clustering.value
     git_repo = argument.git_repo.value
     git_rev = argument.git_rev.value
@@ -113,6 +134,7 @@ module.git "scrape_kubelet" {
   arguments {
     forward_to = [prometheus.remote_write.destination.receiver]
     tenant = argument.tenant.value
+    keep_metrics = argument.keep_kubelet_metrics.value
     clustering = argument.clustering.value
     git_repo = argument.git_repo.value
     git_rev = argument.git_rev.value
@@ -145,6 +167,7 @@ module.git "scrape_kube_apiserver" {
   arguments {
     forward_to = [prometheus.remote_write.destination.receiver]
     tenant = argument.tenant.value
+    drop_metrics = argument.drop_apiserver_metrics.value
     clustering = argument.clustering.value
     git_repo = argument.git_repo.value
     git_rev = argument.git_rev.value
@@ -161,6 +184,7 @@ module.git "scrape_endpoints" {
   arguments {
     forward_to = [prometheus.remote_write.destination.receiver]
     tenant = argument.tenant.value
+    keep_metrics = argument.keep_ksm_nex_metrics.value
     clustering = argument.clustering.value
     scrape_port_named_metrics = argument.scrape_port_named_metrics.value
     git_repo = argument.git_repo.value

--- a/modules/kubernetes/metrics/scrapes/auto-scrape-endpoints.river
+++ b/modules/kubernetes/metrics/scrapes/auto-scrape-endpoints.river
@@ -61,6 +61,11 @@ argument "scrape_port_named_metrics" {
   default = false
 }
 
+argument "keep_metrics" {
+  // comment = "Regex of metrics to keep, see ../relabelings/kube-state-metrics.river and ../relabelings/node-exporter.river for the default value"
+  optional = true
+}
+
 argument "clustering" {
   // comment = "Whether or not clustering should be enabled"
   optional = true
@@ -114,6 +119,7 @@ module.git "relabelings_kube_state_metrics" {
 
   arguments {
     forward_to = [module.git.relabelings_node_exporter.exports.metric_relabelings.receiver]
+    keep_metrics = argument.keep_metrics.value
   }
 }
 
@@ -125,6 +131,7 @@ module.git "relabelings_node_exporter" {
 
   arguments {
     forward_to = [module.git.relabelings_opencost.exports.metric_relabelings.receiver]
+    keep_metrics = argument.keep_metrics.value
   }
 }
 

--- a/modules/kubernetes/metrics/scrapes/kube-apiserver.river
+++ b/modules/kubernetes/metrics/scrapes/kube-apiserver.river
@@ -13,6 +13,11 @@ argument "tenant" {
   default = ".*"
 }
 
+argument "drop_metrics" {
+  // comment = "Regex of metrics to drop, see ../relabelings/kube-apiserver.river for the default value"
+  optional = true
+}
+
 argument "clustering" {
   // comment = "Whether or not clustering should be enabled"
   optional = true
@@ -95,5 +100,6 @@ module.git "relabelings_kube_apiserver" {
 
   arguments {
     forward_to = argument.forward_to.value
+    drop_metrics = argument.drop_metrics.value
   }
 }

--- a/modules/kubernetes/metrics/scrapes/kubelet-cadvisor.river
+++ b/modules/kubernetes/metrics/scrapes/kubelet-cadvisor.river
@@ -13,6 +13,11 @@ argument "tenant" {
   default = ".*"
 }
 
+argument "keep_metrics" {
+  // comment = "Regex of metrics to keep, see ../relabelings/kubelet-cadvisor.river for the default value"
+  optional = true
+}
+
 argument "clustering" {
   // comment = "Whether or not clustering should be enabled"
   optional = true
@@ -88,5 +93,6 @@ module.git "relabelings_kubelet_cadvisor" {
 
   arguments {
     forward_to = argument.forward_to.value
+    keep_metrics = argument.keep_metrics.value
   }
 }

--- a/modules/kubernetes/metrics/scrapes/kubelet.river
+++ b/modules/kubernetes/metrics/scrapes/kubelet.river
@@ -13,6 +13,11 @@ argument "tenant" {
   default = ".*"
 }
 
+argument "keep_metrics" {
+  // comment = "Regex of metrics to keep, see ../relabelings/kubelet.river for the default value"
+  optional = true
+}
+
 argument "clustering" {
   // comment = "Whether or not clustering should be enabled"
   optional = true
@@ -88,5 +93,6 @@ module.git "relabelings_kubelet" {
 
   arguments {
     forward_to = argument.forward_to.value
+    keep_metrics = argument.keep_metrics.value
   }
 }


### PR DESCRIPTION
`keep-metrics` argument is defined with default value and used in following files:

- relabelings/kubelet.river
- relabelings/kubelet-cadvisor.river
- relabelings/kube-state-metrics.river
- relabelings/node-exporter.river

But this argument is not defined in caller modules to update based on use-case.

This PR will allow one to define custom value for `keep-metrics` while calling `metrics/all.river` in grafana-agent configuration file and it will be propagated down to modules in relabelings folder.