### PR TITLE
K8s annotations writer arg

### DIFF
--- a/example/kubernetes/logs/simple-events.river
+++ b/example/kubernetes/logs/simple-events.river
@@ -12,13 +12,25 @@ module.git "event_logs" {
   path       = "modules/kubernetes/logs/events.river"
 
   arguments {
-    loki_url = env("LOGS_OPS_URL")
-    loki_username = env("LOGS_OPS_TENANT")
-    loki_password = env("LOGS_OPS_TOKEN")
-    label_cluster = coalesce(env("CLUSTER_NAME"), env("CLUSTER"), "")
-    label_env = coalesce(env("ENV"), "")
-    label_region = coalesce(env("REGION"), "")
+    forward_to = [loki.write.default.receiver]
     git_repo = coalesce(env("GIT_REPO"), env("AGENT_REPO"), "https://github.com/grafana/agent-modules.git")
     git_rev = coalesce(env("GIT_REV"), env("AGENT_REV"), "main")
+  }
+}
+
+loki.write "default" {
+  endpoint {
+    url = env("LOGS_OPS_URL")
+
+    basic_auth {
+        username = env("LOGS_OPS_TENANT")
+        password = env("LOGS_OPS_TOKEN")
+    }
+  }
+
+  external_labels = {
+    "cluster" = coalesce(env("CLUSTER_NAME"), env("CLUSTER"), ""),
+    "env" = coalesce(env("ENV"), ""),
+    "region" = coalesce(env("REGION"), ""),
   }
 }

--- a/example/kubernetes/logs/simple-multi-tenant.river
+++ b/example/kubernetes/logs/simple-multi-tenant.river
@@ -14,10 +14,8 @@ module.git "logs_primary" {
   path = "modules/kubernetes/logs/all.river"
 
   arguments {
-    loki_url = env("LOKI_ENDPOINT")
-    loki_username = env("DEFAULT_TENANT_ID")
-    loki_password = env("DEFAULT_TENANT_TOKEN")
-    tenant = coalesce(env("DEFAULT_TENANT_NAME"), "primary|")
+    forward_to = [loki.write.primary.receiver]
+    tenant = "primary|"
     git_repo = "https://github.com/grafana/agent-modules.git"
     git_rev = "main"
   }
@@ -29,11 +27,43 @@ module.git "logs_op" {
   path = "modules/kubernetes/logs/all.river"
 
   arguments {
-    loki_url = env("LOKI_ENDPOINT")
-    loki_username = env("OPS_TENANT_ID")
-    loki_password = env("OPS_TENANT_TOKEN")
+    forward_to = [loki.write.default.receiver]
     tenant = coalesce(env("OPS_TENANT_NAME"), "ops")
     git_repo = "https://github.com/grafana/agent-modules.git"
     git_rev = "main"
+  }
+}
+
+loki.write "local_primary" {
+  endpoint {
+    url = env("LOGS_PRIMARY_URL")
+
+    basic_auth {
+        username = env("LOGS_PRIMARY_TENANT")
+        password = env("LOGS_PRIMARY_TOKEN")
+    }
+  }
+
+  external_labels = {
+    "cluster" = coalesce(env("CLUSTER_NAME"), env("CLUSTER"), ""),
+    "env" = coalesce(env("ENV"), ""),
+    "region" = coalesce(env("REGION"), ""),
+  }
+}
+
+loki.write "local_ops" {
+  endpoint {
+    url = env("LOGS_OPS_URL")
+
+    basic_auth {
+        username = env("LOGS_OPS_TENANT")
+        password = env("LOGS_OPS_TOKEN")
+    }
+  }
+
+  external_labels = {
+    "cluster" = coalesce(env("CLUSTER_NAME"), env("CLUSTER"), ""),
+    "env" = coalesce(env("ENV"), ""),
+    "region" = coalesce(env("REGION"), ""),
   }
 }

--- a/example/kubernetes/logs/simple-single-tenant-journal.river
+++ b/example/kubernetes/logs/simple-single-tenant-journal.river
@@ -1,7 +1,6 @@
 /*
 The following example shows using the default all logs processing module, for
-a single tenant and specifying the destination url/credentials via environment
-variables.
+a single tenant and gathering kubelet logs
 */
 logging {
   level  = "info"
@@ -12,6 +11,18 @@ module.git "logs_primary" {
   repository = "https://github.com/grafana/agent-modules.git"
   revision = "main"
   path = "modules/kubernetes/logs/all.river"
+
+  arguments {
+    forward_to = [loki.write.default.receiver]
+    git_repo = coalesce(env("GIT_REPO"), env("AGENT_REPO"), "https://github.com/grafana/agent-modules.git")
+    git_rev = coalesce(env("GIT_REV"), env("AGENT_REV"), "main")
+  }
+}
+
+module.git "logs_kubelet_journal" {
+  repository = "https://github.com/grafana/agent-modules.git"
+  revision   = "main"
+  path       = "modules/kubernetes/logs/kubelet.river"
 
   arguments {
     forward_to = [loki.write.default.receiver]

--- a/example/kubernetes/logs/single-tenant-custom-pipeline.river
+++ b/example/kubernetes/logs/single-tenant-custom-pipeline.river
@@ -19,7 +19,7 @@ module.git "log_targets" {
   path = "modules/kubernetes/logs/targets/logs-from-worker.river"
 
   arguments {
-    forward_to = module.git.log_formats_all.exports.process.receiver
+    forward_to = [module.git.log_formats_all.exports.process.receiver]
     tenant = coalesce(env("DEFAULT_TENANT_NAME"), "primary|")
   }
 }
@@ -53,7 +53,7 @@ module.git "log_level_default" {
   path = "modules/kubernetes/logs/labels/log-level.river"
 
   arguments {
-    forward_to = module.git.scrub_all.exports.process.receiver
+    forward_to = [module.git.scrub_all.exports.process.receiver]
   }
 }
 
@@ -63,7 +63,7 @@ module.git "drop_levels" {
   path = "modules/kubernetes/logs/drops/levels.river"
 
   arguments {
-    forward_to = module.git.scrub_all.exports.process.receiver
+    forward_to = [module.git.scrub_all.exports.process.receiver]
   }
 }
 
@@ -73,7 +73,7 @@ module.git "scrub_all" {
   path = "modules/kubernetes/logs/scrubs/all.river"
 
   arguments {
-    forward_to = module.git.embed_pod.exports.process.receiver
+    forward_to = [module.git.embed_pod.exports.process.receiver]
   }
 }
 
@@ -83,7 +83,7 @@ module.git "embed_pod" {
   path = "modules/kubernetes/logs/embed/pod.river"
 
   arguments {
-    forward_to = module.git.label_keep.exports.process.receiver
+    forward_to = [module.git.label_keep.exports.process.receiver]
   }
 }
 

--- a/example/kubernetes/logs/single-tenant-no-masking.river
+++ b/example/kubernetes/logs/single-tenant-no-masking.river
@@ -17,7 +17,7 @@ module.git "log_targets" {
   path = "modules/kubernetes/logs/targets/logs-from-worker.river"
 
   arguments {
-    forward_to = module.git.log_formats_all.exports.process.receiver
+    forward_to = [module.git.log_formats_all.exports.process.receiver]
     tenant = coalesce(env("DEFAULT_TENANT_NAME"), "primary|")
   }
 }
@@ -28,7 +28,7 @@ module.git "log_formats_all" {
   path = "modules/kubernetes/logs/log-formats/all.river"
 
   arguments {
-    forward_to = module.git.log_level_default.exports.process.receiver
+    forward_to = [module.git.log_level_default.exports.process.receiver]
   }
 }
 
@@ -38,7 +38,7 @@ module.git "log_level_default" {
   path = "modules/kubernetes/logs/labels/log-level.river"
 
   arguments {
-    forward_to = module.git.scrub_all.exports.process.receiver
+    forward_to = [module.git.scrub_all.exports.process.receiver]
   }
 }
 
@@ -48,7 +48,7 @@ module.git "drop_levels" {
   path = "modules/kubernetes/logs/drops/levels.river"
 
   arguments {
-    forward_to = module.git.scrub_all.exports.process.receiver
+    forward_to = [module.git.scrub_all.exports.process.receiver]
   }
 }
 
@@ -58,7 +58,7 @@ module.git "scrub_all" {
   path = "modules/kubernetes/logs/scrubs/all.river"
 
   arguments {
-    forward_to = module.git.embed_pod.exports.process.receiver
+    forward_to = [module.git.embed_pod.exports.process.receiver]
   }
 }
 
@@ -68,7 +68,7 @@ module.git "embed_pod" {
   path = "modules/kubernetes/logs/embed/pod.river"
 
   arguments {
-    forward_to = module.git.label_keep.exports.process.receiver
+    forward_to = [module.git.label_keep.exports.process.receiver]
   }
 }
 

--- a/example/kubernetes/logs/single-tenant-specific-log-formats.river
+++ b/example/kubernetes/logs/single-tenant-specific-log-formats.river
@@ -20,7 +20,7 @@ module.git "log_targets" {
   path = "modules/kubernetes/logs/targets/logs-from-worker.river"
 
   arguments {
-    forward_to = module.git.log_format_json.exports.process.receiver
+    forward_to = [module.git.log_format_json.exports.process.receiver]
     tenant = coalesce(env("DEFAULT_TENANT_NAME"), "primary|")
   }
 }
@@ -31,7 +31,7 @@ module.git "log_format_json" {
   path = "modules/kubernetes/logs/log-formats/json.river"
 
   arguments {
-    forward_to = module.git.log_format_klog.exports.process.receiver
+    forward_to = [module.git.log_format_klog.exports.process.receiver]
   }
 }
 
@@ -41,7 +41,7 @@ module.git "log_format_klog" {
   path = "modules/kubernetes/logs/log-formats/klog.river"
 
   arguments {
-    forward_to = module.git.log_format_logfmt.exports.process.receiver
+    forward_to = [module.git.log_format_logfmt.exports.process.receiver]
   }
 }
 
@@ -51,7 +51,7 @@ module.git "log_format_logfmt" {
   path = "modules/kubernetes/logs/log-formats/logfmt.river"
 
   arguments {
-    forward_to = module.git.log_level_default.exports.process.receiver
+    forward_to = [module.git.log_level_default.exports.process.receiver]
   }
 }
 
@@ -61,7 +61,7 @@ module.git "log_level_default" {
   path = "modules/kubernetes/logs/labels/log-level.river"
 
   arguments {
-    forward_to = module.git.scrub_all.exports.process.receiver
+    forward_to = [module.git.scrub_all.exports.process.receiver]
   }
 }
 
@@ -71,7 +71,7 @@ module.git "drop_levels" {
   path = "modules/kubernetes/logs/drops/levels.river"
 
   arguments {
-    forward_to = module.git.scrub_all.exports.process.receiver
+    forward_to = [module.git.scrub_all.exports.process.receiver]
   }
 }
 
@@ -81,7 +81,7 @@ module.git "scrub_all" {
   path = "modules/kubernetes/logs/scrubs/all.river"
 
   arguments {
-    forward_to = module.git.embed_pod.exports.process.receiver
+    forward_to = [module.git.embed_pod.exports.process.receiver]
   }
 }
 
@@ -91,7 +91,7 @@ module.git "embed_pod" {
   path = "modules/kubernetes/logs/embed/pod.river"
 
   arguments {
-    forward_to = module.git.label_keep.exports.process.receiver
+    forward_to = [module.git.label_keep.exports.process.receiver]
   }
 }
 

--- a/example/kubernetes/metrics/custom-rewrites.river
+++ b/example/kubernetes/metrics/custom-rewrites.river
@@ -1,5 +1,5 @@
 /*
-The following example shows using the default all metrics processing module, for
+The following example shows specific modules, kubernetes scrapes only, for
 a single tenant and specifying the destination url/credentials via environment
 variables.
 */
@@ -8,15 +8,27 @@ logging {
   format = "logfmt"
 }
 
-module.git "metrics_primary" {
-  repository = "https://github.com/grafana/agent-modules.git"
-  revision   = "main"
-  path       = "modules/kubernetes/metrics/all.river"
+module.git "scrape_endpoints" {
+  repository = argument.git_repo.value
+  revision = argument.git_rev.value
+  pull_frequency = argument.git_pull_freq.value
+  path = "modules/kubernetes/metrics/scrapes/auto-scrape-endpoints.river"
 
   arguments {
-    forward_to = [prometheus.remote_write.local_primary.receiver]
-    blackbox_url = "blackbox-prometheus-blackbox-exporter.agents.svc.cluster.local:9115"
+    forward_to = [prometheus.relabel.custom.receiver]
   }
+}
+
+prometheus.relabel "custom" {
+  forward_to = [prometheus.remote_write.local_primary.receiver]
+
+  // example rule to drop any go_* metrics
+  rule {
+    action = "drop"
+    source_labels = ["__name__"]
+    regex = "go_.*"
+  }
+
 }
 
 prometheus.remote_write "local_primary" {

--- a/example/kubernetes/metrics/multi-target-example.river
+++ b/example/kubernetes/metrics/multi-target-example.river
@@ -1,0 +1,74 @@
+/*
+The following example shows using the default all metrics processing module, for
+a single tenant and specifying the destination url/credentials via environment
+variables.
+*/
+logging {
+  level  = coalesce(env("AGENT_LOG_LEVEL"), "info")
+  format = "logfmt"
+}
+
+module.git "metrics_primary" {
+  repository = "https://github.com/grafana/agent-modules.git"
+  revision   = "main"
+  path       = "modules/kubernetes/metrics/all.river"
+
+  arguments {
+    forward_to = [
+      prometheus.remote_write.local_primary.receiver,
+      prometheus.remote_write.grafana_cloud.receiver,
+    ]
+    blackbox_url = "blackbox-prometheus-blackbox-exporter.agents.svc.cluster.local:9115"
+  }
+}
+
+prometheus.remote_write "local_primary" {
+  endpoint {
+    url = env("METRICS_PRIMARY_URL")
+
+    basic_auth {
+      username = env("METRICS_PRIMARY_TENANT")
+      password = env("METRICS_PRIMARY_TOKEN")
+    }
+
+    write_relabel_config {
+			replacement = coalesce(env("CLUSTER_NAME"), env("CLUSTER"), "")
+			target_label  = "cluster"
+		}
+
+    write_relabel_config {
+			replacement = coalesce(env("ENV"), "")
+			target_label  = "env"
+		}
+
+    write_relabel_config {
+			replacement = coalesce(env("REGION"), "")
+			target_label  = "region"
+		}
+  }
+}
+
+prometheus.remote_write "grafana_cloud" {
+  endpoint {
+    url = "https://prometheus-us-central1.grafana.net/api/prom/push"
+
+    basic_auth {
+      username = "XXXXXX"
+      password = "XXXXXX"
+    }
+
+    write_relabel_config {
+			replacement = coalesce(env("CLUSTER_NAME"), env("CLUSTER"), "")
+			target_label  = "cluster"
+		}
+
+    write_relabel_config {
+			replacement = coalesce(env("ENV"), "")
+			target_label  = "env"
+		}
+
+    write_relabel_config {
+			replacement = coalesce(env("REGION"), "")
+			target_label  = "region"
+		}
+  }

--- a/example/kubernetes/metrics/selective-modules.river
+++ b/example/kubernetes/metrics/selective-modules.river
@@ -1,5 +1,5 @@
 /*
-The following example shows using the default all metrics processing module, for
+The following example shows specific modules, kubernetes scrapes only, for
 a single tenant and specifying the destination url/credentials via environment
 variables.
 */
@@ -8,45 +8,43 @@ logging {
   format = "logfmt"
 }
 
-module.git "metrics_primary" {
+module.git "scrape_kubelet_cadvisor" {
   repository = "https://github.com/grafana/agent-modules.git"
   revision   = "main"
-  path       = "modules/kubernetes/metrics/all.river"
+  path = "modules/kubernetes/metrics/scrapes/kubelet-cadvisor.river"
 
   arguments {
     forward_to = [prometheus.remote_write.local_primary.receiver]
-    blackbox_url = "blackbox-prometheus-blackbox-exporter.agents.svc.cluster.local:9115"
   }
 }
 
-/*
-The json exporter modules are not included in the default all.river, as it is not as common.  Include the json-services and/or json-ingress module,
-and set the forward_to to be the exporter writer from the all.river module or declare a new instance of the prometheus.remote_write component.
-Ensure JSON Exporter is installed in the cluster and the json_exporter_url is set to the service name and port of the json exporter.
-
-Docs: https://github.com/prometheus-community/json_exporter/tree/master
-Helm Chart: https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-json-exporter
-*/
-
-module.git "json_services" {
+module.git "scrape_kubelet" {
   repository = "https://github.com/grafana/agent-modules.git"
   revision   = "main"
-  path = "modules/kubernetes/metrics/scrapes/json-services.river"
+  path = "modules/kubernetes/metrics/scrapes/kubelet.river"
 
   arguments {
     forward_to = [prometheus.remote_write.local_primary.receiver]
-    json_exporter_url = "json-exporter.agents.svc.cluster.local:7979"
   }
 }
 
-module.git "json_ingresses" {
+module.git "scrape_kubelet_probes" {
   repository = "https://github.com/grafana/agent-modules.git"
   revision   = "main"
-  path = "modules/kubernetes/metrics/scrapes/json-ingresses.river"
+  path = "modules/kubernetes/metrics/scrapes/kubelet-probes.river"
 
   arguments {
     forward_to = [prometheus.remote_write.local_primary.receiver]
-    json_exporter_url = "json-exporter.agents.svc.cluster.local:7979"
+  }
+}
+
+module.git "scrape_kube_apiserver" {
+  repository = "https://github.com/grafana/agent-modules.git"
+  revision   = "main"
+  path = "modules/kubernetes/metrics/scrapes/kube-apiserver.river"
+
+  arguments {
+    forward_to = [prometheus.remote_write.local_primary.receiver]
   }
 }
 

--- a/example/kubernetes/metrics/simple-multi-tenant.river
+++ b/example/kubernetes/metrics/simple-multi-tenant.river
@@ -14,9 +14,7 @@ module.git "metrics_primary" {
   path       = "modules/kubernetes/metrics/all.river"
 
   arguments {
-    mimir_url = env("METRICS_PRIMARY_URL")
-    mimir_username = env("METRICS_PRIMARY_TENANT")
-    mimir_password = env("METRICS_PRIMARY_TOKEN")
+    forward_to = [prometheus.remote_write.local_primary.receiver]
     // match aything with the annotation:
     // metrics.agent.grafana.com/tenant: primary or the annotation is not set
     tenant = "primary|"
@@ -30,11 +28,61 @@ module.git "metrics_ops" {
   path       = "modules/kubernetes/metrics/all.river"
 
   arguments {
-    mimir_url = env("METRICS_OPS_URL")
-    mimir_username = env("METRICS_OPS_TENANT")
-    mimir_password = env("METRICS_OPS_TOKEN")
+    forward_to = [prometheus.remote_write.local_ops.receiver]
     // metrics.agent.grafana.com/tenant: ops
     tenant = "ops"
     blackbox_url = "blackbox-prometheus-blackbox-exporter.agents.svc.cluster.local:9115"
+  }
+}
+
+prometheus.remote_write "local_primary" {
+  endpoint {
+    url = env("METRICS_PRIMARY_URL")
+
+    basic_auth {
+      username = env("METRICS_PRIMARY_TENANT")
+      password = env("METRICS_PRIMARY_TOKEN")
+    }
+
+    write_relabel_config {
+			replacement = coalesce(env("CLUSTER_NAME"), env("CLUSTER"), "")
+			target_label  = "cluster"
+		}
+
+    write_relabel_config {
+			replacement = coalesce(env("ENV"), "")
+			target_label  = "env"
+		}
+
+    write_relabel_config {
+			replacement = coalesce(env("REGION"), "")
+			target_label  = "region"
+		}
+  }
+}
+
+prometheus.remote_write "local_ops" {
+  endpoint {
+    url = env("METRICS_OPS_URL")
+
+    basic_auth {
+      username = env("METRICS_OPS_TENANT")
+      password = env("METRICS_OPS_TOKEN")
+    }
+
+    write_relabel_config {
+			replacement = coalesce(env("CLUSTER_NAME"), env("CLUSTER"), "")
+			target_label  = "cluster"
+		}
+
+    write_relabel_config {
+			replacement = coalesce(env("ENV"), "")
+			target_label  = "env"
+		}
+
+    write_relabel_config {
+			replacement = coalesce(env("REGION"), "")
+			target_label  = "region"
+		}
   }
 }

--- a/modules/kubernetes/logs/all.river
+++ b/modules/kubernetes/logs/all.river
@@ -2,45 +2,15 @@
 Module: log-all
 Description: Wrapper module to include all kubernetes logging modules and use cri parsing
 */
-
-argument "loki_url" {
-  // comment = "The full URL address of Loki including the protocol, host and path i.e. https://example.com/loki/api/v1/push"
-  optional = false
-}
-
-argument "loki_username" {
-  // comment = "The Loki Username / Tenant ID"
-  optional = false
-}
-
-argument "loki_password" {
-  // comment = "The Loki Password / Token for the Tenant"
-  optional = true
-  default = ""
+argument "forward_to" {
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
+	optional = false
 }
 
 argument "tenant" {
   // comment = "The tenant to filter logs to.  This does not have to be the tenantId, this is the value to look for in the logs.agent.grafana.com/tenant annotation, and this can be a regex."
   optional = true
   default = ".*"
-}
-
-argument "label_cluster" {
-  // comment = "Static cluster label to add to all collected metrics"
-  optional = true
-  default = ""
-}
-
-argument "label_env" {
-  // comment = "Static env label to add to all collected metrics"
-  optional = true
-  default = ""
-}
-
-argument "label_region" {
-  // comment = "Static region label to add to all collected metrics"
-  optional = true
-  default = ""
 }
 
 argument "keep_labels" {
@@ -77,12 +47,9 @@ argument "git_rev" {
 }
 
 argument "git_pull_freq" {
+  // comment = "How often to pull the git repo, the default is 0s which means never pull"
   optional = true
-  default = "5m"
-}
-
-export "loki_remote" {
-  value = loki.write.destination
+  default = "0s"
 }
 
 module.git "log_targets" {
@@ -196,24 +163,7 @@ module.git "label_keep" {
   path = "modules/kubernetes/logs/labels/keep-labels.river"
 
   arguments {
-    forward_to = loki.write.destination.receiver
+    forward_to = argument.forward_to.value
     keep_labels = argument.keep_labels.value
-  }
-}
-
-loki.write "destination" {
-  endpoint {
-    url = argument.loki_url.value
-
-    basic_auth {
-        username = argument.loki_username.value
-        password = argument.loki_password.value
-    }
-  }
-
-  external_labels = {
-    "cluster" = argument.label_cluster.value,
-    "env" = argument.label_env.value,
-    "region" = argument.label_region.value,
   }
 }

--- a/modules/kubernetes/logs/all.river
+++ b/modules/kubernetes/logs/all.river
@@ -59,7 +59,7 @@ module.git "log_targets" {
   path = "modules/kubernetes/logs/targets/logs-from-worker.river"
 
   arguments {
-    forward_to = module.git.log_formats_all.exports.process.receiver
+    forward_to = [module.git.log_formats_all.exports.process.receiver]
     tenant = argument.tenant.value
     git_repo = argument.git_repo.value
     git_rev = argument.git_rev.value
@@ -74,7 +74,7 @@ module.git "log_formats_all" {
   path = "modules/kubernetes/logs/log-formats/all.river"
 
   arguments {
-    forward_to = module.git.log_level_default.exports.process.receiver
+    forward_to = [module.git.log_level_default.exports.process.receiver]
     git_repo = argument.git_repo.value
     git_rev = argument.git_rev.value
     git_pull_freq = argument.git_pull_freq.value
@@ -88,7 +88,7 @@ module.git "log_level_default" {
   path = "modules/kubernetes/logs/labels/log-level.river"
 
   arguments {
-    forward_to = module.git.drop_levels.exports.process.receiver
+    forward_to = [module.git.drop_levels.exports.process.receiver]
   }
 }
 
@@ -99,7 +99,7 @@ module.git "drop_levels" {
   path = "modules/kubernetes/logs/drops/levels.river"
 
   arguments {
-    forward_to = module.git.scrub_all.exports.process.receiver
+    forward_to = [module.git.scrub_all.exports.process.receiver]
     git_repo = argument.git_repo.value
     git_rev = argument.git_rev.value
     git_pull_freq = argument.git_pull_freq.value
@@ -113,7 +113,7 @@ module.git "scrub_all" {
   path = "modules/kubernetes/logs/scrubs/all.river"
 
   arguments {
-    forward_to = module.git.embed_pod.exports.process.receiver
+    forward_to = [module.git.embed_pod.exports.process.receiver]
     git_repo = argument.git_repo.value
     git_rev = argument.git_rev.value
     git_pull_freq = argument.git_pull_freq.value
@@ -127,7 +127,7 @@ module.git "embed_pod" {
   path = "modules/kubernetes/logs/embed/pod.river"
 
   arguments {
-    forward_to = module.git.mask_all.exports.process.receiver
+    forward_to = [module.git.mask_all.exports.process.receiver]
   }
 }
 
@@ -138,7 +138,7 @@ module.git "mask_all" {
   path = "modules/kubernetes/logs/masks/all.river"
 
   arguments {
-    forward_to = module.git.label_normalize_filename.exports.process.receiver
+    forward_to = [module.git.label_normalize_filename.exports.process.receiver]
     git_repo = argument.git_repo.value
     git_rev = argument.git_rev.value
     git_pull_freq = argument.git_pull_freq.value
@@ -152,7 +152,7 @@ module.git "label_normalize_filename" {
   path = "modules/kubernetes/logs/labels/normalize-filename.river"
 
   arguments {
-    forward_to = module.git.label_keep.exports.process.receiver
+    forward_to = [module.git.label_keep.exports.process.receiver]
   }
 }
 

--- a/modules/kubernetes/logs/drops/level-debug.river
+++ b/modules/kubernetes/logs/drops/level-debug.river
@@ -15,7 +15,7 @@ export "process" {
 }
 
 loki.process "drop_debug" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/drop-debug annotation, if not set or set to true then drop
   // any log message with level=debug

--- a/modules/kubernetes/logs/drops/level-debug.river
+++ b/modules/kubernetes/logs/drops/level-debug.river
@@ -6,7 +6,7 @@ Description: The default behavior is to drop debug level messaging automatically
              logs.agent.grafana.com/drop-debug: false
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/drops/level-info.river
+++ b/modules/kubernetes/logs/drops/level-info.river
@@ -16,7 +16,7 @@ export "process" {
 }
 
 loki.process "drop_info" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/drop-info annotation, if not set or set to true then drop
   // any log message with level=info

--- a/modules/kubernetes/logs/drops/level-info.river
+++ b/modules/kubernetes/logs/drops/level-info.river
@@ -6,7 +6,7 @@ Description: The default behavior is to keep info level messaging automatically,
              logs.agent.grafana.com/drop-info: true
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/drops/level-info.river
+++ b/modules/kubernetes/logs/drops/level-info.river
@@ -10,7 +10,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.drop_info
 }

--- a/modules/kubernetes/logs/drops/level-trace.river
+++ b/modules/kubernetes/logs/drops/level-trace.river
@@ -10,7 +10,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.drop_trace
 }

--- a/modules/kubernetes/logs/drops/level-trace.river
+++ b/modules/kubernetes/logs/drops/level-trace.river
@@ -6,7 +6,7 @@ Description: The default behavior is to drop trace level messaging automatically
              logs.agent.grafana.com/drop-trace: false
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/drops/level-trace.river
+++ b/modules/kubernetes/logs/drops/level-trace.river
@@ -16,7 +16,7 @@ export "process" {
 }
 
 loki.process "drop_trace" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/drop-trace annotation, if not set or set to true then drop
   // any log message with level=trace

--- a/modules/kubernetes/logs/drops/levels.river
+++ b/modules/kubernetes/logs/drops/levels.river
@@ -3,7 +3,7 @@ Module: drop-levels
 Description: Wrapper module to include all drop level modules
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/drops/levels.river
+++ b/modules/kubernetes/logs/drops/levels.river
@@ -34,7 +34,7 @@ module.git "drop_trace" {
   path = "modules/kubernetes/logs/drops/level-trace.river"
 
   arguments {
-    forward_to = module.git.drop_debug.exports.process.receiver
+    forward_to = [module.git.drop_debug.exports.process.receiver]
   }
 }
 
@@ -45,7 +45,7 @@ module.git "drop_debug" {
   path = "modules/kubernetes/logs/drops/level-debug.river"
 
   arguments {
-    forward_to = module.git.drop_info.exports.process.receiver
+    forward_to = [module.git.drop_info.exports.process.receiver]
   }
 }
 

--- a/modules/kubernetes/logs/drops/levels.river
+++ b/modules/kubernetes/logs/drops/levels.river
@@ -7,7 +7,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 argument "git_repo" {
   optional = true
   default = coalesce(env("GIT_REPO"), "https://github.com/grafana/agent-modules.git")

--- a/modules/kubernetes/logs/embed/pod.river
+++ b/modules/kubernetes/logs/embed/pod.river
@@ -7,7 +7,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.embed_pod
 }

--- a/modules/kubernetes/logs/embed/pod.river
+++ b/modules/kubernetes/logs/embed/pod.river
@@ -13,7 +13,7 @@ export "process" {
 }
 
 loki.process "embed_pod" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/embed-pod annotation, if true embed the name of the pod to the end of the log line
   // this can reduce the overall cardinality, by not using a label of "pod", individual pods can still be searched

--- a/modules/kubernetes/logs/embed/pod.river
+++ b/modules/kubernetes/logs/embed/pod.river
@@ -3,7 +3,7 @@ Module: embed-pod
 Description: Embeds the name of the pod to the json or text log line
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/events.river
+++ b/modules/kubernetes/logs/events.river
@@ -4,21 +4,9 @@ Description: Retrieves and processes kubernetes events.  This module should only
              a single replica.  As events are captured from API calls, any more than a single pod would result in duplicate
               events being sent to Loki.
 */
-
-argument "loki_url" {
-  // comment = "The full URL address of Loki including the protocol, host and path i.e. https://example.com/loki/api/v1/push"
-  optional = false
-}
-
-argument "loki_username" {
-  // comment = "The Loki Username / Tenant ID"
-  optional = false
-}
-
-argument "loki_password" {
-  // comment = "The Loki Password / Token for the Tenant"
-  optional = true
-  default = ""
+argument "forward_to" {
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
+	optional = false
 }
 
 argument "namespaces" {
@@ -31,24 +19,6 @@ argument "label_job" {
   // comment = "The job label to set for all collected logs"
   optional = true
   default = "integrations/kubernetes/eventhandler"
-}
-
-argument "label_cluster" {
-  // comment = "Static cluster label to add to all collected metrics"
-  optional = true
-  default = ""
-}
-
-argument "label_env" {
-  // comment = "Static env label to add to all collected metrics"
-  optional = true
-  default = ""
-}
-
-argument "label_region" {
-  // comment = "Static region label to add to all collected metrics"
-  optional = true
-  default = ""
 }
 
 argument "keep_labels" {
@@ -94,10 +64,6 @@ argument "git_rev" {
 argument "git_pull_freq" {
   optional = true
   default = "5m"
-}
-
-export "loki_remote" {
-  value = loki.write.destination
 }
 
 loki.source.kubernetes_events "events" {
@@ -237,24 +203,7 @@ module.git "label_keep" {
   path = "modules/kubernetes/logs/labels/keep-labels.river"
 
   arguments {
-    forward_to = loki.write.destination.receiver
+    forward_to = [argument.forward_to.value]
     keep_labels = argument.keep_labels.value
-  }
-}
-
-loki.write "destination" {
-  endpoint {
-    url = argument.loki_url.value
-
-    basic_auth {
-        username = argument.loki_username.value
-        password = argument.loki_password.value
-    }
-  }
-
-  external_labels = {
-    "cluster" = argument.label_cluster.value,
-    "env" = argument.label_env.value,
-    "region" = argument.label_region.value,
   }
 }

--- a/modules/kubernetes/logs/events.river
+++ b/modules/kubernetes/logs/events.river
@@ -189,7 +189,7 @@ module.git "drop_levels" {
   path = "modules/kubernetes/logs/drops/levels.river"
 
   arguments {
-    forward_to = module.git.label_keep.exports.process.receiver
+    forward_to = [module.git.label_keep.exports.process.receiver]
     git_repo = argument.git_repo.value
     git_rev = argument.git_rev.value
     git_pull_freq = argument.git_pull_freq.value
@@ -203,7 +203,7 @@ module.git "label_keep" {
   path = "modules/kubernetes/logs/labels/keep-labels.river"
 
   arguments {
-    forward_to = [argument.forward_to.value]
+    forward_to = argument.forward_to.value
     keep_labels = argument.keep_labels.value
   }
 }

--- a/modules/kubernetes/logs/events.river
+++ b/modules/kubernetes/logs/events.river
@@ -110,7 +110,7 @@ module.git "log_format_logfmt" {
   path = "modules/kubernetes/logs/log-formats/logfmt.river"
 
   arguments {
-    forward_to = loki.process.events.receiver
+    forward_to = [loki.process.events.receiver]
   }
 }
 

--- a/modules/kubernetes/logs/kubelet.river
+++ b/modules/kubernetes/logs/kubelet.river
@@ -2,21 +2,9 @@
 Module: log-kubelet
 Description: Retrieves and processes the systemd journal logs for the kubelet
 */
-
-argument "loki_url" {
-  // comment = "The full URL address of Loki including the protocol, host and path i.e. https://example.com/loki/api/v1/push"
+argument "forward_to" {
+  // comment = "The module to forward the output to"
   optional = false
-}
-
-argument "loki_username" {
-  // comment = "The Loki Username / Tenant ID"
-  optional = false
-}
-
-argument "loki_password" {
-  // comment = "The Loki Password / Token for the Tenant"
-  optional = true
-  default = ""
 }
 
 argument "journal_max_age" {
@@ -59,24 +47,6 @@ argument "label_job" {
   // comment = "The job label to set for all collected logs"
   optional = true
   default = "loki.source.journal.kubelet"
-}
-
-argument "label_cluster" {
-  // comment = "Static cluster label to add to all collected metrics"
-  optional = true
-  default = ""
-}
-
-argument "label_env" {
-  // comment = "Static env label to add to all collected metrics"
-  optional = true
-  default = ""
-}
-
-argument "label_region" {
-  // comment = "Static region label to add to all collected metrics"
-  optional = true
-  default = ""
 }
 
 argument "keep_labels" {
@@ -263,25 +233,7 @@ module.git "label_keep" {
   path = "modules/kubernetes/logs/labels/keep-labels.river"
 
   arguments {
-    forward_to = loki.write.destination.receiver
+    forward_to = argument.forward_to.value
     keep_labels = argument.keep_labels.value
-  }
-}
-
-loki.write "destination" {
-  endpoint {
-    url = argument.loki_url.value
-
-    basic_auth {
-        username = argument.loki_username.value
-        password = argument.loki_password.value
-    }
-  }
-
-  external_labels = {
-    "cluster" = argument.label_cluster.value,
-    "env" = argument.label_env.value,
-    "region" = argument.label_region.value,
-    "job" = argument.label_job.value,
   }
 }

--- a/modules/kubernetes/logs/kubelet.river
+++ b/modules/kubernetes/logs/kubelet.river
@@ -3,7 +3,7 @@ Module: log-kubelet
 Description: Retrieves and processes the systemd journal logs for the kubelet
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/kubelet.river
+++ b/modules/kubernetes/logs/kubelet.river
@@ -82,10 +82,6 @@ argument "git_pull_freq" {
   default = "5m"
 }
 
-export "loki_remote" {
-  value = loki.write.destination
-}
-
 loki.relabel "journal" {
   forward_to = []
 

--- a/modules/kubernetes/logs/kubelet.river
+++ b/modules/kubernetes/logs/kubelet.river
@@ -205,7 +205,7 @@ module.git "log_format_klog" {
   path = "modules/kubernetes/logs/log-formats/klog.river"
 
   arguments {
-    forward_to = module.git.log_format_logfmt.exports.process.receiver
+    forward_to = [module.git.log_format_logfmt.exports.process.receiver]
   }
 }
 
@@ -216,7 +216,7 @@ module.git "log_format_logfmt" {
   path = "modules/kubernetes/logs/log-formats/logfmt.river"
 
   arguments {
-    forward_to = module.git.log_format_syslog.exports.process.receiver
+    forward_to = [module.git.log_format_syslog.exports.process.receiver]
   }
 }
 
@@ -227,7 +227,7 @@ module.git "log_format_syslog" {
   path = "modules/kubernetes/logs/log-formats/syslog.river"
 
   arguments {
-    forward_to = module.git.log_level_default.exports.process.receiver
+    forward_to = [module.git.log_level_default.exports.process.receiver]
   }
 }
 
@@ -238,7 +238,7 @@ module.git "log_level_default" {
   path = "modules/kubernetes/logs/labels/log-level.river"
 
   arguments {
-    forward_to = module.git.drop_levels.exports.process.receiver
+    forward_to = [module.git.drop_levels.exports.process.receiver]
   }
 }
 
@@ -249,7 +249,7 @@ module.git "drop_levels" {
   path = "modules/kubernetes/logs/drops/levels.river"
 
   arguments {
-    forward_to = module.git.label_keep.exports.process.receiver
+    forward_to = [module.git.label_keep.exports.process.receiver]
     git_repo = argument.git_repo.value
     git_rev = argument.git_rev.value
     git_pull_freq = argument.git_pull_freq.value

--- a/modules/kubernetes/logs/labels/keep-labels.river
+++ b/modules/kubernetes/logs/labels/keep-labels.river
@@ -44,7 +44,7 @@ Not every log has to contain these labels, but this list should reflect the set 
 to explicitly allow.
 */
 loki.process "keep_labels" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   stage.label_keep {
     values = argument.keep_labels.value

--- a/modules/kubernetes/logs/labels/keep-labels.river
+++ b/modules/kubernetes/logs/labels/keep-labels.river
@@ -9,7 +9,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 argument "keep_labels" {
   optional = true
   // comment = "List of labels to keep before the log message is written to Loki"
@@ -36,6 +35,7 @@ argument "keep_labels" {
 export "process" {
   value = loki.process.keep_labels
 }
+
 /*
 As all of the pod labels and annotations we transformed into labels in the previous relabelings to make
 them available to the pipeline processing we need to ensure they are not automatically created in Loki.

--- a/modules/kubernetes/logs/labels/keep-labels.river
+++ b/modules/kubernetes/logs/labels/keep-labels.river
@@ -5,7 +5,7 @@ Description: Pre-defined set of labels to keep, this stage should always be in-p
               in Loki as that would have extremely high-cardinality.
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/labels/log-level.river
+++ b/modules/kubernetes/logs/labels/log-level.river
@@ -5,7 +5,7 @@ Description: Sets a default log level of "unknown", then based on known patterns
              as there are modules for parsing specific log patterns.
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/labels/log-level.river
+++ b/modules/kubernetes/logs/labels/log-level.river
@@ -14,7 +14,7 @@ export "process" {
 }
 
 loki.process "log_level" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // if a log level is not set, default it to unknown
   stage.match {

--- a/modules/kubernetes/logs/labels/normalize-filename.river
+++ b/modules/kubernetes/logs/labels/normalize-filename.river
@@ -22,7 +22,7 @@ Example:
   Becomes: /var/log/pods/agents/agent-logs-grafana-agent/config-reloader.log
 */
 loki.process "normalize_filename" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   stage.regex {
     // unescaped regex: ^(?P<path>\/([^\/_]+\/)+)[^\/]+\/(?P<container_folder>[^\/]+)\/[0-9]+\.log

--- a/modules/kubernetes/logs/labels/normalize-filename.river
+++ b/modules/kubernetes/logs/labels/normalize-filename.river
@@ -3,7 +3,7 @@ Module: normalize-filename
 Description: Normalizes the kubernetes filename name, and reduces cardinality of the filename
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/labels/normalize-filename.river
+++ b/modules/kubernetes/logs/labels/normalize-filename.river
@@ -7,10 +7,10 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.normalize_filename
 }
+
 /*
 Normalize the filename, the label "filename" is automatically created from
 discovered files in the matching path based on the __path__ label from the

--- a/modules/kubernetes/logs/log-formats/all.river
+++ b/modules/kubernetes/logs/log-formats/all.river
@@ -33,7 +33,7 @@ module.git "log_format_common_log" {
   path = "modules/kubernetes/logs/log-formats/common-log.river"
 
   arguments {
-    forward_to = module.git.log_format_dotnet.exports.process.receiver
+    forward_to = [module.git.log_format_dotnet.exports.process.receiver]
   }
 }
 
@@ -44,7 +44,7 @@ module.git "log_format_dotnet" {
   path = "modules/kubernetes/logs/log-formats/dotnet.river"
 
   arguments {
-    forward_to = module.git.log_format_istio.exports.process.receiver
+    forward_to = [module.git.log_format_istio.exports.process.receiver]
   }
 }
 
@@ -55,7 +55,7 @@ module.git "log_format_istio" {
   path = "modules/kubernetes/logs/log-formats/istio.river"
 
   arguments {
-    forward_to = module.git.log_format_json.exports.process.receiver
+    forward_to = [module.git.log_format_json.exports.process.receiver]
   }
 }
 
@@ -66,7 +66,7 @@ module.git "log_format_json" {
   path = "modules/kubernetes/logs/log-formats/json.river"
 
   arguments {
-    forward_to = module.git.log_format_klog.exports.process.receiver
+    forward_to = [module.git.log_format_klog.exports.process.receiver]
   }
 }
 
@@ -77,7 +77,7 @@ module.git "log_format_klog" {
   path = "modules/kubernetes/logs/log-formats/klog.river"
 
   arguments {
-    forward_to = module.git.log_format_log4j.exports.process.receiver
+    forward_to = [module.git.log_format_log4j.exports.process.receiver]
   }
 }
 
@@ -88,7 +88,7 @@ module.git "log_format_log4j" {
   path = "modules/kubernetes/logs/log-formats/log4j.river"
 
   arguments {
-    forward_to = module.git.log_format_logfmt.exports.process.receiver
+    forward_to = [module.git.log_format_logfmt.exports.process.receiver]
   }
 }
 
@@ -99,7 +99,7 @@ module.git "log_format_logfmt" {
   path = "modules/kubernetes/logs/log-formats/logfmt.river"
 
   arguments {
-    forward_to = module.git.log_format_otel.exports.process.receiver
+    forward_to = [module.git.log_format_otel.exports.process.receiver]
   }
 }
 
@@ -110,7 +110,7 @@ module.git "log_format_otel" {
   path = "modules/kubernetes/logs/log-formats/otel.river"
 
   arguments {
-    forward_to = module.git.log_format_postgres.exports.process.receiver
+    forward_to = [module.git.log_format_postgres.exports.process.receiver]
   }
 }
 
@@ -121,7 +121,7 @@ module.git "log_format_postgres" {
   path = "modules/kubernetes/logs/log-formats/otel.river"
 
   arguments {
-    forward_to = module.git.log_format_python.exports.process.receiver
+    forward_to = [module.git.log_format_python.exports.process.receiver]
   }
 }
 
@@ -132,7 +132,7 @@ module.git "log_format_python" {
   path = "modules/kubernetes/logs/log-formats/python.river"
 
   arguments {
-    forward_to = module.git.log_format_spring_boot.exports.process.receiver
+    forward_to = [module.git.log_format_spring_boot.exports.process.receiver]
   }
 }
 
@@ -143,7 +143,7 @@ module.git "log_format_spring_boot" {
   path = "modules/kubernetes/logs/log-formats/spring-boot.river"
 
   arguments {
-    forward_to = module.git.log_format_syslog.exports.process.receiver
+    forward_to = [module.git.log_format_syslog.exports.process.receiver]
   }
 }
 
@@ -154,7 +154,7 @@ module.git "log_format_syslog" {
   path = "modules/kubernetes/logs/log-formats/syslog.river"
 
   arguments {
-    forward_to = module.git.log_format_zerolog.exports.process.receiver
+    forward_to = [module.git.log_format_zerolog.exports.process.receiver]
   }
 }
 

--- a/modules/kubernetes/logs/log-formats/all.river
+++ b/modules/kubernetes/logs/log-formats/all.river
@@ -3,7 +3,7 @@ Module: log-format-all
 Description: Wrapper module to include all log-format modules
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/log-formats/common-log.river
+++ b/modules/kubernetes/logs/log-formats/common-log.river
@@ -4,7 +4,7 @@ Description: Log Processing for common-log (apache/nginx)
 Docs: https://www.w3.org/Daemon/User/Config/Logging.html#common-logfile-format
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/log-formats/common-log.river
+++ b/modules/kubernetes/logs/log-formats/common-log.river
@@ -13,7 +13,7 @@ export "process" {
 }
 
 loki.process "log_format_clf" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains clf and the line matches the format, then process the line as clf
   stage.match {

--- a/modules/kubernetes/logs/log-formats/dotnet.river
+++ b/modules/kubernetes/logs/log-formats/dotnet.river
@@ -13,7 +13,7 @@ export "process" {
 }
 
 loki.process "log_format_dotnet" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains python-json and the line matches the format, then process the line as python-json
   stage.match {

--- a/modules/kubernetes/logs/log-formats/dotnet.river
+++ b/modules/kubernetes/logs/log-formats/dotnet.river
@@ -4,7 +4,7 @@ Description: Log Processing for .Net
 Docs: https://learn.microsoft.com/en-us/dotnet/core/extensions/console-log-formatter#json
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/log-formats/istio.river
+++ b/modules/kubernetes/logs/log-formats/istio.river
@@ -4,7 +4,7 @@ Description: Log Processing for istio
 Docs: https://istio.io/latest/docs/tasks/observability/logs/access-log/
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/log-formats/istio.river
+++ b/modules/kubernetes/logs/log-formats/istio.river
@@ -13,7 +13,7 @@ export "process" {
 }
 
 loki.process "log_format_istio" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains istio and the line matches the format, then process the line as json
   stage.match {

--- a/modules/kubernetes/logs/log-formats/json.river
+++ b/modules/kubernetes/logs/log-formats/json.river
@@ -12,7 +12,7 @@ export "process" {
 }
 
 loki.process "log_format_json" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains json and the line matches the format, then process the line as json
   stage.match {

--- a/modules/kubernetes/logs/log-formats/json.river
+++ b/modules/kubernetes/logs/log-formats/json.river
@@ -3,7 +3,7 @@ Module: log-format-json
 Description: Log Processing for Generic JSON
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/log-formats/klog.river
+++ b/modules/kubernetes/logs/log-formats/klog.river
@@ -4,7 +4,7 @@ Description: Log Processing for klog (used by kube-state-metrics and more in kub
 Docs: https://github.com/kubernetes/klog
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/log-formats/klog.river
+++ b/modules/kubernetes/logs/log-formats/klog.river
@@ -13,7 +13,7 @@ export "process" {
 }
 
 loki.process "log_format_klog" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains klog and the line matches the format, then process the line as
   // a klog (https://github.com/kubernetes/klog)

--- a/modules/kubernetes/logs/log-formats/log4j.river
+++ b/modules/kubernetes/logs/log-formats/log4j.river
@@ -14,7 +14,7 @@ export "process" {
 }
 
 loki.process "log_format_log4j" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains log4j-json and the line matches the format, then process the line as log4j-json
   stage.match {

--- a/modules/kubernetes/logs/log-formats/log4j.river
+++ b/modules/kubernetes/logs/log-formats/log4j.river
@@ -5,7 +5,7 @@ Docs: https://logging.apache.org/log4j/2.x/manual/layouts.html#json-template-lay
       https://github.com/logstash/log4j-jsonevent-layout
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/log-formats/logfmt.river
+++ b/modules/kubernetes/logs/log-formats/logfmt.river
@@ -12,7 +12,7 @@ export "process" {
 }
 
 loki.process "log_format_logfmt" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains logfmt and the line matches the format, then process the line as
   // a logfmt (https://github.com/go-logfmt/logfmt)

--- a/modules/kubernetes/logs/log-formats/logfmt.river
+++ b/modules/kubernetes/logs/log-formats/logfmt.river
@@ -3,7 +3,7 @@ Module: log-format-logfmt
 Description: Handles formatting for log format of logfmt which is the default Golang format
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/log-formats/otel.river
+++ b/modules/kubernetes/logs/log-formats/otel.river
@@ -13,7 +13,7 @@ export "process" {
 }
 
 loki.process "log_format_otel" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains otel and the line matches the format, then process the line as otel
   stage.match {

--- a/modules/kubernetes/logs/log-formats/otel.river
+++ b/modules/kubernetes/logs/log-formats/otel.river
@@ -4,7 +4,7 @@ Description: Log Processing for OpenTelemetry
 Docs: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/log-formats/postgres.river
+++ b/modules/kubernetes/logs/log-formats/postgres.river
@@ -13,7 +13,7 @@ export "process" {
 }
 
 loki.process "log_format_postgres" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains postgres then process the line
   stage.match {

--- a/modules/kubernetes/logs/log-formats/postgres.river
+++ b/modules/kubernetes/logs/log-formats/postgres.river
@@ -4,7 +4,7 @@ Description: Handles formatting for log format of Postgres
 Docs: https://www.postgresql.org/docs/current/runtime-config-logging.html
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/log-formats/python.river
+++ b/modules/kubernetes/logs/log-formats/python.river
@@ -3,7 +3,7 @@ Module: log-format-python
 Description: Log Processing for Python
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/log-formats/python.river
+++ b/modules/kubernetes/logs/log-formats/python.river
@@ -12,7 +12,7 @@ export "process" {
 }
 
 loki.process "log_format_python" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains python-json and the line matches the format, then process the line as python-json
   stage.match {

--- a/modules/kubernetes/logs/log-formats/spring-boot.river
+++ b/modules/kubernetes/logs/log-formats/spring-boot.river
@@ -13,7 +13,7 @@ export "process" {
 }
 
 loki.process "log_format_spring_boot" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains springboot and the line matches the format, then process the line as spring-boot
   stage.match {

--- a/modules/kubernetes/logs/log-formats/spring-boot.river
+++ b/modules/kubernetes/logs/log-formats/spring-boot.river
@@ -4,7 +4,7 @@ Description: Log Processing for Spring Boot
 Docs: https://docs.spring.io/spring-boot/docs/2.1.13.RELEASE/reference/html/boot-features-logging.html
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/log-formats/syslog.river
+++ b/modules/kubernetes/logs/log-formats/syslog.river
@@ -13,7 +13,7 @@ export "process" {
 }
 
 loki.process "log_format_syslog" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains postgres then process the line
   stage.match {

--- a/modules/kubernetes/logs/log-formats/syslog.river
+++ b/modules/kubernetes/logs/log-formats/syslog.river
@@ -4,7 +4,7 @@ Description: Handles formatting for log format of syslog
 Docs: https://datatracker.ietf.org/doc/html/rfc5424
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/log-formats/zerolog.river
+++ b/modules/kubernetes/logs/log-formats/zerolog.river
@@ -4,7 +4,7 @@ Description: Handles formatting for log format of zerolog
 Docs: https://github.com/rs/zerolog
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/log-formats/zerolog.river
+++ b/modules/kubernetes/logs/log-formats/zerolog.river
@@ -13,7 +13,7 @@ export "process" {
 }
 
 loki.process "log_format_zerolog" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/log-format annotation, if the log_type is empty the line hasn't been processed, if it contains postgres then process the line
   stage.match {

--- a/modules/kubernetes/logs/masks/all.river
+++ b/modules/kubernetes/logs/masks/all.river
@@ -3,7 +3,7 @@ Module: mask-all
 Description: Wrapper module to include all masking modules
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/masks/all.river
+++ b/modules/kubernetes/logs/masks/all.river
@@ -33,7 +33,7 @@ module.git "mask_ssn" {
   path = "modules/kubernetes/logs/masks/ssn.river"
 
   arguments {
-    forward_to = module.git.mask_credit_card.exports.process.receiver
+    forward_to = [module.git.mask_credit_card.exports.process.receiver]
   }
 }
 
@@ -44,7 +44,7 @@ module.git "mask_credit_card" {
   path = "modules/kubernetes/logs/masks/credit-card.river"
 
   arguments {
-    forward_to = module.git.mask_email.exports.process.receiver
+    forward_to = [module.git.mask_email.exports.process.receiver]
   }
 }
 
@@ -55,7 +55,7 @@ module.git "mask_email" {
   path = "modules/kubernetes/logs/masks/email.river"
 
   arguments {
-    forward_to = module.git.mask_phone.exports.process.receiver
+    forward_to = [module.git.mask_phone.exports.process.receiver]
   }
 }
 
@@ -66,7 +66,7 @@ module.git "mask_phone" {
   path = "modules/kubernetes/logs/masks/phone.river"
 
   arguments {
-    forward_to = module.git.mask_ipv4.exports.process.receiver
+    forward_to = [module.git.mask_ipv4.exports.process.receiver]
   }
 }
 
@@ -77,7 +77,7 @@ module.git "mask_ipv4" {
   path = "modules/kubernetes/logs/masks/ipv4.river"
 
   arguments {
-    forward_to = module.git.mask_ipv6.exports.process.receiver
+    forward_to = [module.git.mask_ipv6.exports.process.receiver]
   }
 }
 

--- a/modules/kubernetes/logs/masks/credit-card.river
+++ b/modules/kubernetes/logs/masks/credit-card.river
@@ -4,7 +4,7 @@ Description: Checks the logs.agent.grafana.com/mask-credit-card annotation, if s
              card pattern will have the value of the credit card replaced with "*credit-card*hash*
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/masks/credit-card.river
+++ b/modules/kubernetes/logs/masks/credit-card.river
@@ -8,7 +8,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.mask_credit_card
 }

--- a/modules/kubernetes/logs/masks/credit-card.river
+++ b/modules/kubernetes/logs/masks/credit-card.river
@@ -14,7 +14,7 @@ export "process" {
 }
 
 loki.process "mask_credit_card" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/mask-credit-card annotation, if true the data will be masked as *credit-card*salt*
   // Formats:

--- a/modules/kubernetes/logs/masks/email.river
+++ b/modules/kubernetes/logs/masks/email.river
@@ -4,7 +4,7 @@ Description: Checks the logs.agent.grafana.com/mask-email annotation, if set to 
              pattern will have the value of the email replaced with "*email*hash*
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/masks/email.river
+++ b/modules/kubernetes/logs/masks/email.river
@@ -8,7 +8,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.mask_email
 }

--- a/modules/kubernetes/logs/masks/email.river
+++ b/modules/kubernetes/logs/masks/email.river
@@ -14,7 +14,7 @@ export "process" {
 }
 
 loki.process "mask_email" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/mask-email annotation, if true the data will be masked as *email*salt*
   stage.match {

--- a/modules/kubernetes/logs/masks/ipv4.river
+++ b/modules/kubernetes/logs/masks/ipv4.river
@@ -14,7 +14,7 @@ export "process" {
 }
 
 loki.process "mask_ipv4" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/mask-ipv4 annotation, if true the data will be masked as *ipv4*salt*
   stage.match {

--- a/modules/kubernetes/logs/masks/ipv4.river
+++ b/modules/kubernetes/logs/masks/ipv4.river
@@ -8,7 +8,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.mask_ipv4
 }

--- a/modules/kubernetes/logs/masks/ipv4.river
+++ b/modules/kubernetes/logs/masks/ipv4.river
@@ -4,7 +4,7 @@ Description: Checks the logs.agent.grafana.com/mask-ipv4 annotation, if set to "
              pattern will have the value of the ipv4 replaced with "*ipv4*hash*
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/masks/ipv6.river
+++ b/modules/kubernetes/logs/masks/ipv6.river
@@ -8,7 +8,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.mask_ipv6
 }

--- a/modules/kubernetes/logs/masks/ipv6.river
+++ b/modules/kubernetes/logs/masks/ipv6.river
@@ -4,7 +4,7 @@ Description: Checks the logs.agent.grafana.com/mask-ipv6 annotation, if set to "
              pattern will have the value of the ipv6 replaced with "*ipv6*hash*
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/masks/ipv6.river
+++ b/modules/kubernetes/logs/masks/ipv6.river
@@ -14,7 +14,7 @@ export "process" {
 }
 
 loki.process "mask_ipv6" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/mask-ipv6 annotation, if true the data will be masked as *ipv6*salt*
   stage.match {

--- a/modules/kubernetes/logs/masks/phone.river
+++ b/modules/kubernetes/logs/masks/phone.river
@@ -4,7 +4,7 @@ Description: Checks the logs.agent.grafana.com/mask-phone annotation, if set to 
              pattern will have the value of the phone replaced with "*phone*hash*
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/masks/phone.river
+++ b/modules/kubernetes/logs/masks/phone.river
@@ -14,7 +14,7 @@ export "process" {
 }
 
 loki.process "mask_phone" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/mask-phone annotation, if true the data will be masked as *phone*salt*
   stage.match {

--- a/modules/kubernetes/logs/masks/phone.river
+++ b/modules/kubernetes/logs/masks/phone.river
@@ -8,7 +8,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.mask_phone
 }

--- a/modules/kubernetes/logs/masks/ssn.river
+++ b/modules/kubernetes/logs/masks/ssn.river
@@ -8,7 +8,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.mask_ssn
 }

--- a/modules/kubernetes/logs/masks/ssn.river
+++ b/modules/kubernetes/logs/masks/ssn.river
@@ -14,7 +14,7 @@ export "process" {
 }
 
 loki.process "mask_ssn" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/mask-ssn annotation, if true the data will be masked as *ssn*salt*
   stage.match {

--- a/modules/kubernetes/logs/masks/ssn.river
+++ b/modules/kubernetes/logs/masks/ssn.river
@@ -4,7 +4,7 @@ Description: Checks the logs.agent.grafana.com/mask-ssn annotation, if set to "t
              pattern will have the value of the ssn replaced with "*ssn*hash*
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/scrubs/all.river
+++ b/modules/kubernetes/logs/scrubs/all.river
@@ -3,7 +3,7 @@ Module: scrub-all
 Description: Wrapper module to include all scrubing modules
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/scrubs/all.river
+++ b/modules/kubernetes/logs/scrubs/all.river
@@ -34,7 +34,7 @@ module.git "scrub_json_empties" {
   path = "modules/kubernetes/logs/scrubs/json-empties.river"
 
   arguments {
-    forward_to = module.git.scrub_json_nulls.exports.process.receiver
+    forward_to = [module.git.scrub_json_nulls.exports.process.receiver]
   }
 }
 

--- a/modules/kubernetes/logs/scrubs/all.river
+++ b/modules/kubernetes/logs/scrubs/all.river
@@ -7,7 +7,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 argument "git_repo" {
   optional = true
   default = coalesce(env("GIT_REPO"), "https://github.com/grafana/agent-modules.git")

--- a/modules/kubernetes/logs/scrubs/json-empties.river
+++ b/modules/kubernetes/logs/scrubs/json-empties.river
@@ -4,7 +4,7 @@ Description: Checks for the annotation logs.agent.grafana.com/scrub-empties, if 
              Removes any json properties with empty values i.e. "foo": "", "bar": [], "baz": {}
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/scrubs/json-empties.river
+++ b/modules/kubernetes/logs/scrubs/json-empties.river
@@ -8,7 +8,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.scrub_json_empties
 }

--- a/modules/kubernetes/logs/scrubs/json-empties.river
+++ b/modules/kubernetes/logs/scrubs/json-empties.river
@@ -14,7 +14,7 @@ export "process" {
 }
 
 loki.process "scrub_json_empties" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/scrub-empties annotation, if true remove any json property whose value is set to
   // an empty string "", empty object {} or empty array [] is removed

--- a/modules/kubernetes/logs/scrubs/json-nulls.river
+++ b/modules/kubernetes/logs/scrubs/json-nulls.river
@@ -8,7 +8,6 @@ argument "forward_to" {
   optional = false
 }
 
-
 export "process" {
   value = loki.process.scrub_json_nulls
 }

--- a/modules/kubernetes/logs/scrubs/json-nulls.river
+++ b/modules/kubernetes/logs/scrubs/json-nulls.river
@@ -14,7 +14,7 @@ export "process" {
 }
 
 loki.process "scrub_json_nulls" {
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 
   // check logs.agent.grafana.com/scrub-nulls annotation, if true remove any json property whose value is set to null
   // this can reduce the overall # of bytes sent and stored in Loki

--- a/modules/kubernetes/logs/scrubs/json-nulls.river
+++ b/modules/kubernetes/logs/scrubs/json-nulls.river
@@ -4,7 +4,7 @@ Description: Checks for the annotation logs.agent.grafana.com/scrub-nulls, if se
              Removes any json properties with a null value
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/targets/logs-from-api.river
+++ b/modules/kubernetes/logs/targets/logs-from-api.river
@@ -4,7 +4,7 @@ Description: Performs Kubernetes service discovery for pods, applies relabelings
              then retrieved from the kubernetes api
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/logs/targets/logs-from-api.river
+++ b/modules/kubernetes/logs/targets/logs-from-api.river
@@ -44,5 +44,5 @@ module.git "relabelings_log" {
 
 loki.source.kubernetes "pods" {
   targets    = module.git.relabelings_log.exports.relabelings.output
-  forward_to = [argument.forward_to.value]
+  forward_to = argument.forward_to.value
 }

--- a/modules/kubernetes/logs/targets/logs-from-worker.river
+++ b/modules/kubernetes/logs/targets/logs-from-worker.river
@@ -81,7 +81,7 @@ loki.source.file "pods" {
 }
 
 loki.process "parse" {
-  forward_to  = [argument.forward_to.value]
+  forward_to  = argument.forward_to.value
 
   // if the label tmp_container_runtime from above is containerd parse using cri
   stage.match {

--- a/modules/kubernetes/logs/targets/logs-from-worker.river
+++ b/modules/kubernetes/logs/targets/logs-from-worker.river
@@ -7,7 +7,7 @@ Description: Performs Kubernetes service discovery for pods, applies relabelings
              node to retrieve the pod logs.
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/metrics/all.river
+++ b/modules/kubernetes/metrics/all.river
@@ -2,39 +2,9 @@
 Module: metrics-all
 Description: Wrapper module to include all kubernetes metric modules and use cri parsing
 */
-
-argument "mimir_url" {
-  // comment = "The full URL address of mimir including the protocol, host and path i.e. https://example.com/api/prom/push"
-  optional = false
-}
-
-argument "mimir_username" {
-  // comment = "The mimir Username / Tenant ID"
-  optional = false
-}
-
-argument "mimir_password" {
-  // comment = "The mimir Password / Token for the Tenant"
-  optional = true
-  default = ""
-}
-
-argument "label_cluster" {
-  // comment = "Static cluster label to add to all collected metrics"
-  optional = true
-  default = ""
-}
-
-argument "label_env" {
-  // comment = "Static env label to add to all collected metrics"
-  optional = true
-  default = ""
-}
-
-argument "label_region" {
-  // comment = "Static region label to add to all collected metrics"
-  optional = true
-  default = ""
+argument "forward_to" {
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
+	optional = false
 }
 
 argument "scrape_port_named_metrics" {
@@ -82,10 +52,6 @@ argument "git_rev" {
 argument "git_pull_freq" {
   optional = true
   default = "5m"
-}
-
-export "prometheus_remote" {
-  value = prometheus.remote_write.destination
 }
 
 module.git "scrape_kubelet_cadvisor" {
@@ -202,31 +168,5 @@ module.git "probe_ingresses" {
     git_repo = argument.git_repo.value
     git_rev = argument.git_rev.value
     git_pull_freq = argument.git_pull_freq.value
-  }
-}
-
-prometheus.remote_write "destination" {
-  endpoint {
-    url = argument.mimir_url.value
-
-    basic_auth {
-      username = argument.mimir_username.value
-      password = argument.mimir_password.value
-    }
-
-    write_relabel_config {
-			replacement = argument.label_cluster.value
-			target_label  = "cluster"
-		}
-
-    write_relabel_config {
-			replacement = argument.label_env.value
-			target_label  = "env"
-		}
-
-    write_relabel_config {
-			replacement = argument.label_region.value
-			target_label  = "region"
-		}
   }
 }

--- a/modules/kubernetes/metrics/all.river
+++ b/modules/kubernetes/metrics/all.river
@@ -61,7 +61,7 @@ module.git "scrape_kubelet_cadvisor" {
   path = "modules/kubernetes/metrics/scrapes/kubelet-cadvisor.river"
 
   arguments {
-    forward_to = [prometheus.remote_write.destination.receiver]
+    forward_to = argument.forward_to.value
     tenant = argument.tenant.value
     clustering = argument.clustering.value
     git_repo = argument.git_repo.value
@@ -77,7 +77,7 @@ module.git "scrape_kubelet" {
   path = "modules/kubernetes/metrics/scrapes/kubelet.river"
 
   arguments {
-    forward_to = [prometheus.remote_write.destination.receiver]
+    forward_to = argument.forward_to.value
     tenant = argument.tenant.value
     clustering = argument.clustering.value
     git_repo = argument.git_repo.value
@@ -93,7 +93,7 @@ module.git "scrape_kubelet_probes" {
   path = "modules/kubernetes/metrics/scrapes/kubelet-probes.river"
 
   arguments {
-    forward_to = [prometheus.remote_write.destination.receiver]
+    forward_to = argument.forward_to.value
     tenant = argument.tenant.value
     clustering = argument.clustering.value
     git_repo = argument.git_repo.value
@@ -109,7 +109,7 @@ module.git "scrape_kube_apiserver" {
   path = "modules/kubernetes/metrics/scrapes/kube-apiserver.river"
 
   arguments {
-    forward_to = [prometheus.remote_write.destination.receiver]
+    forward_to = argument.forward_to.value
     tenant = argument.tenant.value
     clustering = argument.clustering.value
     git_repo = argument.git_repo.value
@@ -125,7 +125,7 @@ module.git "scrape_endpoints" {
   path = "modules/kubernetes/metrics/scrapes/auto-scrape-endpoints.river"
 
   arguments {
-    forward_to = [prometheus.remote_write.destination.receiver]
+    forward_to = argument.forward_to.value
     tenant = argument.tenant.value
     clustering = argument.clustering.value
     scrape_port_named_metrics = argument.scrape_port_named_metrics.value
@@ -142,7 +142,7 @@ module.git "probe_services" {
   path = "modules/kubernetes/metrics/scrapes/auto-probe-services.river"
 
   arguments {
-    forward_to = [prometheus.remote_write.destination.receiver]
+    forward_to = argument.forward_to.value
     tenant = argument.tenant.value
     clustering = argument.clustering.value
     blackbox_url = argument.blackbox_url.value
@@ -160,7 +160,7 @@ module.git "probe_ingresses" {
   path = "modules/kubernetes/metrics/scrapes/auto-probe-ingresses.river"
 
   arguments {
-    forward_to = [prometheus.remote_write.destination.receiver]
+    forward_to = argument.forward_to.value
     tenant = argument.tenant.value
     clustering = argument.clustering.value
     blackbox_url = argument.blackbox_url.value

--- a/modules/kubernetes/metrics/all.river
+++ b/modules/kubernetes/metrics/all.river
@@ -51,7 +51,7 @@ argument "git_rev" {
 
 argument "git_pull_freq" {
   optional = true
-  default = "5m"
+  default = "0s"
 }
 
 module.git "scrape_kubelet_cadvisor" {

--- a/modules/kubernetes/metrics/relabelings/auto-scrape.river
+++ b/modules/kubernetes/metrics/relabelings/auto-scrape.river
@@ -3,7 +3,7 @@ Module: relabelings-auto-scrape
 Description: Handles metric relabelings for collected metrics from auto-scraped targets via annotations
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/metrics/relabelings/blackbox.river
+++ b/modules/kubernetes/metrics/relabelings/blackbox.river
@@ -4,7 +4,7 @@ Description: Handles metric relabelings for collected metrics from blackbox-expo
 Docs: https://github.com/prometheus/blackbox_exporter
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/metrics/relabelings/json-exporter.river
+++ b/modules/kubernetes/metrics/relabelings/json-exporter.river
@@ -4,7 +4,7 @@ Description: Handles metric relabelings for collected metrics from json-exporter
 Docs: https://github.com/prometheus-community/json_exporter
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/metrics/relabelings/kube-apiserver.river
+++ b/modules/kubernetes/metrics/relabelings/kube-apiserver.river
@@ -3,7 +3,7 @@ Module: relabelings-kube-apiserver
 Description: Handles metric relabelings for collected metrics from kubernetes apiserver
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/metrics/relabelings/kube-dns.river
+++ b/modules/kubernetes/metrics/relabelings/kube-dns.river
@@ -3,7 +3,7 @@ Module: relabelings-kube-coredns
 Description: Handles metric relabelings for collected metrics from kubernetes coredns
 */
 argument "forward_to" {
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/metrics/relabelings/kube-state-metrics.river
+++ b/modules/kubernetes/metrics/relabelings/kube-state-metrics.river
@@ -5,7 +5,7 @@ Docs: https://github.com/kubernetes/kube-state-metrics
 */
 argument "forward_to" {
   optional = false
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
 }
 
 argument "job_label" {

--- a/modules/kubernetes/metrics/relabelings/kubelet-cadvisor.river
+++ b/modules/kubernetes/metrics/relabelings/kubelet-cadvisor.river
@@ -4,7 +4,7 @@ Description: Handles metric relabelings for collected metrics from kubelet-cadvi
 */
 argument "forward_to" {
   optional = false
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
 }
 
 argument "job_label" {

--- a/modules/kubernetes/metrics/relabelings/kubelet-probes.river
+++ b/modules/kubernetes/metrics/relabelings/kubelet-probes.river
@@ -4,7 +4,7 @@ Description: Handles metric relabelings for collected metrics from kubelet-probe
 */
 argument "forward_to" {
   optional = false
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
 }
 
 argument "job_label" {

--- a/modules/kubernetes/metrics/relabelings/kubelet-resource.river
+++ b/modules/kubernetes/metrics/relabelings/kubelet-resource.river
@@ -4,7 +4,7 @@ Description: Handles metric relabelings for collected metrics from kubelet-resou
 */
 argument "forward_to" {
   optional = false
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
 }
 
 argument "job_label" {

--- a/modules/kubernetes/metrics/relabelings/kubelet.river
+++ b/modules/kubernetes/metrics/relabelings/kubelet.river
@@ -4,7 +4,7 @@ Description: Handles metric relabelings for collected metrics from kubelet
 */
 argument "forward_to" {
   optional = false
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
 }
 
 argument "job_label" {

--- a/modules/kubernetes/metrics/relabelings/node-exporter.river
+++ b/modules/kubernetes/metrics/relabelings/node-exporter.river
@@ -5,7 +5,7 @@ Docs: https://github.com/prometheus/node_exporter
 */
 argument "forward_to" {
   optional = false
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
 }
 
 argument "job_label" {

--- a/modules/kubernetes/metrics/relabelings/opencost.river
+++ b/modules/kubernetes/metrics/relabelings/opencost.river
@@ -5,7 +5,7 @@ Docs: https://github.com/opencost/opencost
 */
 argument "forward_to" {
   optional = false
-  // comment = "The module to forward the output to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
 }
 
 argument "job_label" {

--- a/modules/kubernetes/metrics/scrapes/auto-probe-ingresses.river
+++ b/modules/kubernetes/metrics/scrapes/auto-probe-ingresses.river
@@ -98,7 +98,7 @@ argument "git_rev" {
 
 argument "git_pull_freq" {
   optional = true
-  default = "5m"
+  default = "0s"
 }
 
 module.git "ingress_targets" {

--- a/modules/kubernetes/metrics/scrapes/auto-probe-ingresses.river
+++ b/modules/kubernetes/metrics/scrapes/auto-probe-ingresses.river
@@ -57,7 +57,7 @@ Description:
   prometheus.io/timeout: 30s
 */
 argument "forward_to" {
-  // comment = "Where to send the results to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/metrics/scrapes/auto-probe-services.river
+++ b/modules/kubernetes/metrics/scrapes/auto-probe-services.river
@@ -57,7 +57,7 @@ Description:
   prometheus.io/timeout: 30s
 */
 argument "forward_to" {
-  // comment = "Where to send the results to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/metrics/scrapes/auto-probe-services.river
+++ b/modules/kubernetes/metrics/scrapes/auto-probe-services.river
@@ -98,7 +98,7 @@ argument "git_rev" {
 
 argument "git_pull_freq" {
   optional = true
-  default = "5m"
+  default = "0s"
 }
 
 module.git "service_targets" {

--- a/modules/kubernetes/metrics/scrapes/auto-scrape-endpoints.river
+++ b/modules/kubernetes/metrics/scrapes/auto-scrape-endpoints.river
@@ -79,7 +79,7 @@ argument "git_rev" {
 
 argument "git_pull_freq" {
   optional = true
-  default = "5m"
+  default = "0s"
 }
 
 module.git "endpoints_targets" {

--- a/modules/kubernetes/metrics/scrapes/auto-scrape-endpoints.river
+++ b/modules/kubernetes/metrics/scrapes/auto-scrape-endpoints.river
@@ -45,7 +45,7 @@ Description:
   prometheus.io/timeout: 30s
 */
 argument "forward_to" {
-  // comment = "Where to send the results to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/metrics/scrapes/auto-scrape-pods.river
+++ b/modules/kubernetes/metrics/scrapes/auto-scrape-pods.river
@@ -80,7 +80,7 @@ argument "git_rev" {
 
 argument "git_pull_freq" {
   optional = true
-  default = "5m"
+  default = "0s"
 }
 
 module.git "pod_targets" {

--- a/modules/kubernetes/metrics/scrapes/auto-scrape-pods.river
+++ b/modules/kubernetes/metrics/scrapes/auto-scrape-pods.river
@@ -52,7 +52,7 @@ Description:
   prometheus.io/timeout: 30s
 */
 argument "forward_to" {
-  // comment = "Where to send the results to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/metrics/scrapes/json-ingresses.river
+++ b/modules/kubernetes/metrics/scrapes/json-ingresses.river
@@ -55,7 +55,7 @@ Description:
   prometheus.io/timeout: 30s
 */
 argument "forward_to" {
-  // comment = "Where to send the results to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/metrics/scrapes/json-ingresses.river
+++ b/modules/kubernetes/metrics/scrapes/json-ingresses.river
@@ -88,7 +88,7 @@ argument "git_rev" {
 
 argument "git_pull_freq" {
   optional = true
-  default = "5m"
+  default = "0s"
 }
 
 module.git "ingress_targets" {

--- a/modules/kubernetes/metrics/scrapes/json-services.river
+++ b/modules/kubernetes/metrics/scrapes/json-services.river
@@ -55,7 +55,7 @@ Description:
   prometheus.io/timeout: 30s
 */
 argument "forward_to" {
-  // comment = "Where to send the results to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/metrics/scrapes/json-services.river
+++ b/modules/kubernetes/metrics/scrapes/json-services.river
@@ -88,7 +88,7 @@ argument "git_rev" {
 
 argument "git_pull_freq" {
   optional = true
-  default = "5m"
+  default = "0s"
 }
 
 module.git "service_targets" {

--- a/modules/kubernetes/metrics/scrapes/kube-apiserver.river
+++ b/modules/kubernetes/metrics/scrapes/kube-apiserver.river
@@ -3,7 +3,7 @@ Module: scrape-kube-apiserver
 Description: Scrapes Kube apiserver, most of these same metrics can come from cAdvisor use only if necessary
 */
 argument "forward_to" {
-  // comment = "Where to send the results to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/metrics/scrapes/kube-apiserver.river
+++ b/modules/kubernetes/metrics/scrapes/kube-apiserver.river
@@ -31,7 +31,7 @@ argument "git_rev" {
 
 argument "git_pull_freq" {
   optional = true
-  default = "5m"
+  default = "0s"
 }
 
 // get the available endpoints

--- a/modules/kubernetes/metrics/scrapes/kube-dns.river
+++ b/modules/kubernetes/metrics/scrapes/kube-dns.river
@@ -38,7 +38,7 @@ argument "git_rev" {
 
 argument "git_pull_freq" {
   optional = true
-  default = "5m"
+  default = "0s"
 }
 
 // get the available endpoints

--- a/modules/kubernetes/metrics/scrapes/kube-dns.river
+++ b/modules/kubernetes/metrics/scrapes/kube-dns.river
@@ -10,7 +10,7 @@ Description: Scrapes Kube dns, most of these same metrics can come from cAdvisor
 
 */
 argument "forward_to" {
-  // comment = "Where to send the results to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/metrics/scrapes/kube-state-metrics.river
+++ b/modules/kubernetes/metrics/scrapes/kube-state-metrics.river
@@ -43,7 +43,7 @@ argument "git_rev" {
 
 argument "git_pull_freq" {
   optional = true
-  default = "5m"
+  default = "0s"
 }
 
 // get the available endpoints

--- a/modules/kubernetes/metrics/scrapes/kube-state-metrics.river
+++ b/modules/kubernetes/metrics/scrapes/kube-state-metrics.river
@@ -5,7 +5,7 @@ Description: Scrapes Kube-State-Metrics, this is a separate scrape job, if you a
              metrics.agent.grafana.cmo/scrape: "false"
 */
 argument "forward_to" {
-  // comment = "Where to send the results to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/metrics/scrapes/kubelet-cadvisor.river
+++ b/modules/kubernetes/metrics/scrapes/kubelet-cadvisor.river
@@ -31,7 +31,7 @@ argument "git_rev" {
 
 argument "git_pull_freq" {
   optional = true
-  default = "5m"
+  default = "0s"
 }
 
 module.git "node_targets" {

--- a/modules/kubernetes/metrics/scrapes/kubelet-cadvisor.river
+++ b/modules/kubernetes/metrics/scrapes/kubelet-cadvisor.river
@@ -3,7 +3,7 @@ Module: scrape-kubelet-cadvisor
 Description: Scrapes cAdvisor (Container Advisor Metrics)
 */
 argument "forward_to" {
-  // comment = "Where to send the results to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/metrics/scrapes/kubelet-probes.river
+++ b/modules/kubernetes/metrics/scrapes/kubelet-probes.river
@@ -31,7 +31,7 @@ argument "git_rev" {
 
 argument "git_pull_freq" {
   optional = true
-  default = "5m"
+  default = "0s"
 }
 
 module.git "node_targets" {

--- a/modules/kubernetes/metrics/scrapes/kubelet-probes.river
+++ b/modules/kubernetes/metrics/scrapes/kubelet-probes.river
@@ -3,7 +3,7 @@ Module: scrape-kubelet-probes
 Description: Scrapes Kube probes
 */
 argument "forward_to" {
-  // comment = "Where to send the results to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/metrics/scrapes/kubelet-resource.river
+++ b/modules/kubernetes/metrics/scrapes/kubelet-resource.river
@@ -3,7 +3,7 @@ Module: scrape-kubelet-resource
 Description: Scrapes Kube resource, most of these same metrics can come from cAdvisor use only if necessary
 */
 argument "forward_to" {
-  // comment = "Where to send the results to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/metrics/scrapes/kubelet-resource.river
+++ b/modules/kubernetes/metrics/scrapes/kubelet-resource.river
@@ -31,7 +31,7 @@ argument "git_rev" {
 
 argument "git_pull_freq" {
   optional = true
-  default = "5m"
+  default = "0s"
 }
 
 module.git "node_targets" {

--- a/modules/kubernetes/metrics/scrapes/kubelet.river
+++ b/modules/kubernetes/metrics/scrapes/kubelet.river
@@ -31,7 +31,7 @@ argument "git_rev" {
 
 argument "git_pull_freq" {
   optional = true
-  default = "5m"
+  default = "0s"
 }
 
 module.git "node_targets" {

--- a/modules/kubernetes/metrics/scrapes/kubelet.river
+++ b/modules/kubernetes/metrics/scrapes/kubelet.river
@@ -3,7 +3,7 @@ Module: scrape-kubelet
 Description: Scrapes Kublet Metrics
 */
 argument "forward_to" {
-  // comment = "Where to send the results to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/metrics/scrapes/node-exporter.river
+++ b/modules/kubernetes/metrics/scrapes/node-exporter.river
@@ -7,7 +7,7 @@ Description: Scrapes Node Exporter, this is a separate scrape job, if you are al
              Node exporter should be deployed as a DaemonSet, each pod on each worker will be scraped by the agent using endpoint service discovery
 */
 argument "forward_to" {
-  // comment = "Where to send the results to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/metrics/scrapes/node-exporter.river
+++ b/modules/kubernetes/metrics/scrapes/node-exporter.river
@@ -45,7 +45,7 @@ argument "git_rev" {
 
 argument "git_pull_freq" {
   optional = true
-  default = "5m"
+  default = "0s"
 }
 
 // get the available endpoints

--- a/modules/kubernetes/metrics/scrapes/opencost.river
+++ b/modules/kubernetes/metrics/scrapes/opencost.river
@@ -43,7 +43,7 @@ argument "git_rev" {
 
 argument "git_pull_freq" {
   optional = true
-  default = "5m"
+  default = "0s"
 }
 
 // get the available endpoints

--- a/modules/kubernetes/metrics/scrapes/opencost.river
+++ b/modules/kubernetes/metrics/scrapes/opencost.river
@@ -5,7 +5,7 @@ Description: Scrapes opencost, this is a separate scrape job, if you are also us
              metrics.agent.grafana.cmo/scrape: "false"
 */
 argument "forward_to" {
-  // comment = "Where to send the results to"
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
   optional = false
 }
 

--- a/modules/kubernetes/metrics/targets/endpoints.river
+++ b/modules/kubernetes/metrics/targets/endpoints.river
@@ -26,7 +26,7 @@ argument "git_rev" {
 
 argument "git_pull_freq" {
   optional = true
-  default = "5m"
+  default = "0s"
 }
 
 export "relabelings" {

--- a/modules/kubernetes/metrics/targets/ingresses.river
+++ b/modules/kubernetes/metrics/targets/ingresses.river
@@ -25,7 +25,7 @@ argument "git_rev" {
 
 argument "git_pull_freq" {
   optional = true
-  default = "5m"
+  default = "0s"
 }
 
 export "relabelings" {

--- a/modules/kubernetes/metrics/targets/nodes.river
+++ b/modules/kubernetes/metrics/targets/nodes.river
@@ -20,7 +20,7 @@ argument "git_rev" {
 
 argument "git_pull_freq" {
   optional = true
-  default = "5m"
+  default = "0s"
 }
 
 export "relabelings" {

--- a/modules/kubernetes/metrics/targets/pods.river
+++ b/modules/kubernetes/metrics/targets/pods.river
@@ -20,7 +20,7 @@ argument "git_rev" {
 
 argument "git_pull_freq" {
   optional = true
-  default = "5m"
+  default = "0s"
 }
 
 export "relabelings" {

--- a/modules/kubernetes/metrics/targets/services.river
+++ b/modules/kubernetes/metrics/targets/services.river
@@ -25,7 +25,7 @@ argument "git_rev" {
 
 argument "git_pull_freq" {
   optional = true
-  default = "5m"
+  default = "0s"
 }
 
 export "relabelings" {


### PR DESCRIPTION
Updated the K8s annotation modules to no longer accept credentials as an argument, it now accepts a `forward_to` argument instead which should be a `list(MetricsReceiver)` or `list(LogsReceiver)` instead.  This allows more flexibility for all of the possible connection configurations and/or additional processing of metrics / logs.   Also updated and added a few more examples. 

Resolves #22  and #26 