### PR TITLE
Fixes log4j tag in README.md

### DIFF
--- a/modules/kubernetes/README.md
+++ b/modules/kubernetes/README.md
@@ -8,7 +8,7 @@ The following pod annotations are supported:
 | :--------------- | :-----------|
 | `logs.agent.grafana.com/scrape` | Allow a pod to declare it's logs should be dropped. |
 | `logs.agent.grafana.com/tenant` | Allow a pod to override the tenant for its logs. |
-| `logs.agent.grafana.com/log-format` | If specified additional processing is performed to extract details based on the specified format.  This value can be a comma-delimited list, in the instances a pod may have multiple containers.  The following formats are currently supported: <ul><li>common-log<li>donet<li>istio<li>json<li>klog<li>log4j<li>logfmt<li>otel<li>postgres<li>python<li>spring-boot<li>syslog<li>zerolog</ul> |
+| `logs.agent.grafana.com/log-format` | If specified additional processing is performed to extract details based on the specified format.  This value can be a comma-delimited list, in the instances a pod may have multiple containers.  The following formats are currently supported: <ul><li>common-log<li>donet<li>istio<li>json<li>klog<li>log4j-json<li>logfmt<li>otel<li>postgres<li>python<li>spring-boot<li>syslog<li>zerolog</ul> |
 | `logs.agent.grafana.com/scrub-level` | Boolean whether or not the level should be dropped from the log message (as it is a label). |
 | `logs.agent.grafana.com/scrub-timestamp` | Boolean whether or not the timestamp should be dropped from the log message (as it is metadata). |
 | `logs.agent.grafana.com/scrub-nulls` | Boolean whether or not keys with null values should be dropped from json, reducing the size of the log message. |


### PR DESCRIPTION
README tells to add the pod annotation `logs.agent.grafana.com/log-format` as `log4j` to interpret json log4j format, but the river file actually checks for `log4j-json` string.

https://github.com/grafana/agent-modules/blob/main/modules/kubernetes/README.md?plain=1#L11C56-L11C56

This commit updates the README with the right string