### PR TITLE
feat: add job_label for kubernetes scrape modules

### DIFF
--- a/modules/kubernetes/metrics/scrapes/kube-apiserver.river
+++ b/modules/kubernetes/metrics/scrapes/kube-apiserver.river
@@ -13,6 +13,12 @@ argument "tenant" {
   default = ".*"
 }
 
+argument "job_label" {
+  optional = true
+  default = "integrations/kubernetes/apiserver"
+  // comment = "The job label to add for all apiserver"
+}
+
 argument "clustering" {
   // comment = "Whether or not clustering should be enabled"
   optional = true
@@ -95,5 +101,6 @@ module.git "relabelings_kube_apiserver" {
 
   arguments {
     forward_to = argument.forward_to.value
+    job_label = argument.job_label.value
   }
 }

--- a/modules/kubernetes/metrics/scrapes/kube-dns.river
+++ b/modules/kubernetes/metrics/scrapes/kube-dns.river
@@ -20,6 +20,12 @@ argument "tenant" {
   default = ".*"
 }
 
+argument "job_label" {
+  optional = true
+  default = "integrations/kubernetes/coredns"
+  // comment = "The job label to add for all coredns"
+}
+
 argument "clustering" {
   // comment = "Whether or not clustering should be enabled"
   optional = true
@@ -101,5 +107,6 @@ module.git "relabelings_kube_dns" {
 
   arguments {
     forward_to = argument.forward_to.value
+    job_label = argument.job_label.value
   }
 }

--- a/modules/kubernetes/metrics/scrapes/kubelet-cadvisor.river
+++ b/modules/kubernetes/metrics/scrapes/kubelet-cadvisor.river
@@ -13,6 +13,13 @@ argument "tenant" {
   default = ".*"
 }
 
+argument "job_label" {
+  optional = true
+  // from Grafana Cloud Integration:
+  default = "integrations/kubernetes/cadvisor"
+  // comment = "The job label to add for all cadvisor metrics"
+}
+
 argument "clustering" {
   // comment = "Whether or not clustering should be enabled"
   optional = true
@@ -88,5 +95,6 @@ module.git "relabelings_kubelet_cadvisor" {
 
   arguments {
     forward_to = argument.forward_to.value
+    job_label = argument.job_label.value
   }
 }

--- a/modules/kubernetes/metrics/scrapes/kubelet-probes.river
+++ b/modules/kubernetes/metrics/scrapes/kubelet-probes.river
@@ -13,6 +13,13 @@ argument "tenant" {
   default = ".*"
 }
 
+argument "job_label" {
+  optional = true
+  // from Grafana Cloud Integration:
+  default = "integrations/kubernetes/probes"
+  // comment = "The job label to add for all cadvisor metrics"
+}
+
 argument "clustering" {
   // comment = "Whether or not clustering should be enabled"
   optional = true
@@ -88,5 +95,6 @@ module.git "relabelings_kubelet_probes" {
 
   arguments {
     forward_to = argument.forward_to.value
+    job_label = argument.job_label.value
   }
 }

--- a/modules/kubernetes/metrics/scrapes/kubelet.river
+++ b/modules/kubernetes/metrics/scrapes/kubelet.river
@@ -13,6 +13,13 @@ argument "tenant" {
   default = ".*"
 }
 
+argument "job_label" {
+  optional = true
+  // from Grafana Cloud Integration:
+  default = "integrations/kubernetes/kubelet"
+  // comment = "The job label to add for all kubelet metrics"
+}
+
 argument "clustering" {
   // comment = "Whether or not clustering should be enabled"
   optional = true
@@ -88,5 +95,6 @@ module.git "relabelings_kubelet" {
 
   arguments {
     forward_to = argument.forward_to.value
+    job_label = argument.job_label.value
   }
 }


### PR DESCRIPTION
This PR adds `job_label` to kubernetes scrape modules so it can be passed down to relabeling modules.