### PR TITLE
otelcol.processor.batch should be after otelcol.processor.memory_limiter

### DIFF
--- a/modules/otlp/otlp-to-lgtm/module.river
+++ b/modules/otlp/otlp-to-lgtm/module.river
@@ -58,6 +58,8 @@ otelcol.processor.memory_limiter "default" {
 	}
 }
 
+// otelcol.processor.batch must run after components which can drop telemetry (e.g. otelcol.processor.memory_limiter).
+// Otherwise, if telemetry is dropped, the effect of batching will be lost.
 otelcol.processor.batch "default" {
 	// https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.batch/
 	output {

--- a/modules/otlp/otlp-to-lgtm/module.river
+++ b/modules/otlp/otlp-to-lgtm/module.river
@@ -39,15 +39,6 @@ otelcol.receiver.otlp "default" {
 	}
 
 	output {
-		metrics = [otelcol.processor.batch.default.input]
-		logs    = [otelcol.processor.batch.default.input]
-		traces  = [otelcol.processor.batch.default.input]
-	}
-}
-
-otelcol.processor.batch "default" {
-	// https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.batch/
-	output {
 		metrics = [otelcol.processor.memory_limiter.default.input]
 		logs    = [otelcol.processor.memory_limiter.default.input]
 		traces  = [otelcol.processor.memory_limiter.default.input]
@@ -60,6 +51,15 @@ otelcol.processor.memory_limiter "default" {
 
 	limit = "150MiB" // alternatively, set `limit_percentage` and `spike_limit_percentage`
 
+	output {
+		metrics = [otelcol.processor.batch.default.input]
+		logs    = [otelcol.processor.batch.default.input]
+		traces  = [otelcol.processor.batch.default.input]
+	}
+}
+
+otelcol.processor.batch "default" {
+	// https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.batch/
 	output {
 		metrics = [otelcol.exporter.prometheus.default.input]
 		logs    = [otelcol.exporter.loki.default.input]


### PR DESCRIPTION
The memory limiter processor may drop data, so the batch processor should be after it.
Otherwise some of the batched data might be dropped, which negates the benefits of the batch processor.

This is also mentioned in our [docs](https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.batch/):

> The batch processor should be defined in the pipeline **after** the otelcol.processor.memory_limiter as well as any sampling processors. This is because batching should happen after any data drops such as sampling.

This issue was reported by a user on the [Community Slack](https://grafana.slack.com/archives/C01050C3D8F/p1703232380747149).

cc @gouthamve 