### PR TITLE
K8s Metric Jobs

### DIFF
--- a/modules/kubernetes/metrics/jobs/README.md
+++ b/modules/kubernetes/metrics/jobs/README.md
@@ -36,7 +36,7 @@ The following jobs are completely isolated and have no dependencies on other mod
 | `keep_metrics` | `false` | [see module](./agent.river#L170) | A regex of metrics to keep |
 | `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
 | `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
-| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache.  This should be at least 2x-5x your largest scrape target or samples appended rate. |
 | `clustering` | `false` | `false` | Whether or not clustering should be enabled |
 
 ---
@@ -56,7 +56,7 @@ The following jobs are completely isolated and have no dependencies on other mod
 | `drop_metrics` | `false` | `""` | A regex of metrics to drop |
 | `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
 | `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
-| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache.  This should be at least 2x-5x your largest scrape target or samples appended rate. |
 | `clustering` | `false` | `false` | Whether or not clustering should be enabled |
 
 ---
@@ -76,7 +76,7 @@ The following jobs are completely isolated and have no dependencies on other mod
 | `scrape_port_named_metrics` | `false` | Whether or not to automatically scrape endpoints that have a port with 'metrics' in the name |
 | `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
 | `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
-| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache.  This should be at least 2x-5x your largest scrape target or samples appended rate. |
 | `clustering` | `false` | `false` | Whether or not clustering should be enabled |
 
 ---
@@ -91,7 +91,7 @@ The following jobs are completely isolated and have no dependencies on other mod
 | `keep_metrics` | `false` | [see module](./agent.river#L115) | A regex of metrics to keep |
 | `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
 | `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
-| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache.  This should be at least 2x-5x your largest scrape target or samples appended rate. |
 | `clustering` | `false` | `false` | Whether or not clustering should be enabled |
 
 ---
@@ -109,7 +109,7 @@ The following jobs are completely isolated and have no dependencies on other mod
 | `keep_metrics` | `false` | [see module](./agent.river#L128) | A regex of metrics to keep |
 | `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
 | `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
-| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache.  This should be at least 2x-5x your largest scrape target or samples appended rate. |
 | `clustering` | `false` | `false` | Whether or not clustering should be enabled |
 
 ---
@@ -127,7 +127,7 @@ The following jobs are completely isolated and have no dependencies on other mod
 | `keep_metrics` | `false` | [see module](./agent.river#L128) | A regex of metrics to keep |
 | `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
 | `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
-| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache.  This should be at least 2x-5x your largest scrape target or samples appended rate. |
 | `clustering` | `false` | `false` | Whether or not clustering should be enabled |
 
 ---
@@ -146,7 +146,7 @@ The following jobs are completely isolated and have no dependencies on other mod
 | `drop_les` | `false` | [see module](./kube-apiserver.river#163) | Regex of metric les label values to drop |
 | `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
 | `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
-| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache.  This should be at least 2x-5x your largest scrape target or samples appended rate. |
 | `clustering` | `false` | `false` | Whether or not clustering should be enabled |
 
 ---
@@ -161,7 +161,7 @@ The following jobs are completely isolated and have no dependencies on other mod
 | `keep_metrics` | `false` | [see module](./kube-probes.river#L117) | A regex of metrics to keep |
 | `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
 | `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
-| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache.  This should be at least 2x-5x your largest scrape target or samples appended rate. |
 | `clustering` | `false` | `false` | Whether or not clustering should be enabled |
 
 ---
@@ -179,7 +179,7 @@ The following jobs are completely isolated and have no dependencies on other mod
 | `keep_metrics` | `false` | [see module](./kube-proxy.river#L124) | A regex of metrics to drop |
 | `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
 | `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
-| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache.  This should be at least 2x-5x your largest scrape target or samples appended rate. |
 | `clustering` | `false` | `false` | Whether or not clustering should be enabled |
 
 ---
@@ -194,7 +194,7 @@ The following jobs are completely isolated and have no dependencies on other mod
 | `keep_metrics` | `false` | [see module](./kube-resource.river#L117) | A regex of metrics to keep |
 | `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
 | `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
-| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache.  This should be at least 2x-5x your largest scrape target or samples appended rate. |
 | `clustering` | `false` | `false` | Whether or not clustering should be enabled |
 
 ---
@@ -212,7 +212,7 @@ The following jobs are completely isolated and have no dependencies on other mod
 | `keep_metrics` | `false` | [see module](./kube-state-metrics.river#L127) | A regex of metrics to keep |
 | `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
 | `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
-| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache.  This should be at least 2x-5x your largest scrape target or samples appended rate. |
 | `clustering` | `false` | `false` | Whether or not clustering should be enabled |
 
 ---
@@ -227,7 +227,7 @@ The following jobs are completely isolated and have no dependencies on other mod
 | `keep_metrics` | `false` | [see module](./kubelet.river#L116) | A regex of metrics to keep |
 | `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
 | `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
-| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache.  This should be at least 2x-5x your largest scrape target or samples appended rate. |
 | `clustering` | `false` | `false` | Whether or not clustering should be enabled |
 
 ---
@@ -245,7 +245,7 @@ The following jobs are completely isolated and have no dependencies on other mod
 | `keep_metrics` | `false` | [see module](./loki.river#L186) | A regex of metrics to keep |
 | `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
 | `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
-| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache.  This should be at least 2x-5x your largest scrape target or samples appended rate. |
 | `clustering` | `false` | `false` | Whether or not clustering should be enabled |
 
 ---
@@ -263,7 +263,7 @@ The following jobs are completely isolated and have no dependencies on other mod
 | `keep_metrics` | `false` | [see module](./memcached.river#L170) | A regex of metrics to keep |
 | `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
 | `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
-| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache.  This should be at least 2x-5x your largest scrape target or samples appended rate. |
 | `clustering` | `false` | `false` | Whether or not clustering should be enabled |
 
 ___
@@ -281,7 +281,7 @@ ___
 | `keep_metrics` | `false` | [see module](./mimir.river#L186) | A regex of metrics to keep |
 | `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
 | `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
-| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache.  This should be at least 2x-5x your largest scrape target or samples appended rate. |
 | `clustering` | `false` | `false` | Whether or not clustering should be enabled |
 
 ---
@@ -299,7 +299,7 @@ ___
 | `keep_metrics` | `false` | [see module](./node-exporter.river#L141) | A regex of metrics to keep |
 | `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
 | `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
-| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache.  This should be at least 2x-5x your largest scrape target or samples appended rate. |
 | `clustering` | `false` | `false` | Whether or not clustering should be enabled |
 
 ---
@@ -317,7 +317,7 @@ ___
 | `keep_metrics` | `false` | [see module](./opencost.river#L123) | A regex of metrics to keep |
 | `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
 | `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
-| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache.  This should be at least 2x-5x your largest scrape target or samples appended rate. |
 | `clustering` | `false` | `false` | Whether or not clustering should be enabled |
 
 ---
@@ -349,5 +349,5 @@ ___
 | `keep_metrics` | `false` | [see module](./tempo.river#L183) | A regex of metrics to keep |
 | `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
 | `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
-| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache.  This should be at least 2x-5x your largest scrape target or samples appended rate. |
 | `clustering` | `false` | `false` | Whether or not clustering should be enabled |

--- a/modules/kubernetes/metrics/jobs/README.md
+++ b/modules/kubernetes/metrics/jobs/README.md
@@ -1,0 +1,353 @@
+# Kubernetes Metrics Jobs
+
+The following jobs are completely isolated and have no dependencies on other modules.  Overall, they should be more performant than relying on dependencies of other modules as they are designed to complete a specific task.
+
+## Job Modules
+
+- [Agent](#agent)
+- [Annotations Probe](#annotations-probe)
+- [Annotations Scrape](#annotation-scrape)
+- [cAdvisor](#cadvisor)
+- [Gitlab Exporter](#gitlab-exporter)
+- [Grafana](#grafana)
+- [Kube ApiServer](#kube-apiserver)
+- [Kube Probes](#kube-probes)
+- [Kube Proxy](#kube-proxy)
+- [Kube Resource](#kube-resource)
+- [Kube State Metrics](#kube-state-metrics)
+- [Kubelet](#kubelet)
+- [Loki](#loki)
+- [Mimir](#mimir)
+- [Node Exporter](#node-exporter)
+- [OpenCost](#opencost)
+- [Prometheus Operator](#prometheus-operator)
+- [Tempo](#tempo)
+
+### Agent
+
+| Argument | Required | Default | Description |
+| :------- | :------- | :-------| :---------- |
+| `forward_to` | `true` | _NA_ | Must be a list(MetricsReceiver) where collected logs should be forwarded to |
+| `enabled` | `false` | `true` | Whether or not the grafana-agent job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment |
+| `namespaces` | `false` | `[]` | The namespaces to look for targets in (`[]` is all namespaces) |
+| `selectors` | `false` | `["app.kubernetes.io/name=grafana-agent"]` | The label selectors to use to find matching targets |
+| `port_name` | `false` | `http-metrics` | The of the port to scrape metrics from |
+| `job_label` | `false` | `integrations/agent` | The job label to add for all metrics |
+| `keep_metrics` | `false` | [see module](./agent.river#L170) | A regex of metrics to keep |
+| `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
+| `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `clustering` | `false` | `false` | Whether or not clustering should be enabled |
+
+---
+
+### Annotations Probe
+
+| Argument | Required | Default | Description |
+| :------- | :------- | :-------| :---------- |
+| `forward_to` | `true` | _NA_ | Must be a list(MetricsReceiver) where collected logs should be forwarded to |
+| `role` | `false` | `service` | The role to use when looking for targets to scrape via annotations, can be: service or ingress |
+| `blackbox_url` | `false` | `""` | The address of the blackbox exporter to use (without the protocol), only the hostname and port i.e. blackbox-prometheus-blackbox-exporter.default.svc.cluster.local:9115 |
+| `namespaces` | `false` | `[]` | The namespaces to look for targets in (`[]` is all namespaces) |
+| `selectors` | `false` | `[]` | The label selectors to use to find matching targets |
+| `annotation` | `false` | `probes.grafana.com` | The annotation namespace to use |
+| `tenant` | `false` | `.*` | The tenant to write metrics to.  This does not have to be the tenantId, this is the value to look for in the pro0bes.grafana.com/tenant annotation, and this can be a regex. |
+| `keep_metrics` | `false` | `(.+)` | A regex of metrics to keep |
+| `drop_metrics` | `false` | `""` | A regex of metrics to drop |
+| `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
+| `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `clustering` | `false` | `false` | Whether or not clustering should be enabled |
+
+---
+
+### Annotations Scrape
+
+| Argument | Required | Default | Description |
+| :------- | :------- | :-------| :---------- |
+| `forward_to` | `true` | _NA_ | Must be a list(MetricsReceiver) where collected logs should be forwarded to |
+| `role` | `false` | `service` | The role to use when looking for targets to scrape via annotations, can be: service or ingress |
+| `namespaces` | `false` | `[]` | The namespaces to look for targets in (`[]` is all namespaces) |
+| `selectors` | `false` | `[]` | The label selectors to use to find matching targets |
+| `annotation` | `false` | `probes.grafana.com` | The annotation namespace to use |
+| `tenant` | `false` | `.*` | The tenant to write metrics to.  This does not have to be the tenantId, this is the value to look for in the pro0bes.grafana.com/tenant annotation, and this can be a regex. |
+| `keep_metrics` | `false` | `(.+)` | A regex of metrics to keep |
+| `drop_metrics` | `false` | `""` | A regex of metrics to drop |
+| `scrape_port_named_metrics` | `false` | Whether or not to automatically scrape endpoints that have a port with 'metrics' in the name |
+| `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
+| `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `clustering` | `false` | `false` | Whether or not clustering should be enabled |
+
+---
+
+### cAdvisor
+
+| Argument | Required | Default | Description |
+| :------- | :------- | :-------| :---------- |
+| `forward_to` | `true` | _NA_ | Must be a list(MetricsReceiver) where collected logs should be forwarded to |
+| `enabled` | `false` | `true` | Whether or not the cAdvisor job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment |
+| `job_label` | `false` | `integrations/kubernetes/cadvisor` | The job label to add for all metrics |
+| `keep_metrics` | `false` | [see module](./agent.river#L115) | A regex of metrics to keep |
+| `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
+| `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `clustering` | `false` | `false` | Whether or not clustering should be enabled |
+
+---
+
+### Gitlab Exporter
+
+| Argument | Required | Default | Description |
+| :------- | :------- | :-------| :---------- |
+| `forward_to` | `true` | _NA_ | Must be a list(MetricsReceiver) where collected logs should be forwarded to |
+| `enabled` | `false` | `true` | Whether or not the gitlab-exporter should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment |
+| `namespaces` | `false` | `[]` | The namespaces to look for targets in (`[]` is all namespaces) |
+| `selectors` | `false` | `["app.kubernetes.io/name=gitlab-ci-pipelines-exporter"]` | The label selectors to use to find matching targets |
+| `port_name` | `false` | `http` | The of the port to scrape metrics from |
+| `job_label` | `false` | `integrations/gitlab` | The job label to add for all metrics |
+| `keep_metrics` | `false` | [see module](./agent.river#L128) | A regex of metrics to keep |
+| `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
+| `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `clustering` | `false` | `false` | Whether or not clustering should be enabled |
+
+---
+
+### Grafana
+
+| Argument | Required | Default | Description |
+| :------- | :------- | :-------| :---------- |
+| `forward_to` | `true` | _NA_ | Must be a list(MetricsReceiver) where collected logs should be forwarded to |
+| `enabled` | `false` | `true` | Whether or not the gitlab-exporter should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment |
+| `namespaces` | `false` | `[]` | The namespaces to look for targets in (`[]` is all namespaces) |
+| `selectors` | `false` | `["app.kubernetes.io/name=grafana"]` | The label selectors to use to find matching targets |
+| `port_name` | `false` | `http-metrics` | The of the port to scrape metrics from |
+| `job_label` | `false` | `integrations/gitlab` | The job label to add for all metrics |
+| `keep_metrics` | `false` | [see module](./agent.river#L128) | A regex of metrics to keep |
+| `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
+| `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `clustering` | `false` | `false` | Whether or not clustering should be enabled |
+
+---
+
+### Kube ApiServer
+
+| Argument | Required | Default | Description |
+| :------- | :------- | :-------| :---------- |
+| `forward_to` | `true` | _NA_ | Must be a list(MetricsReceiver) where collected logs should be forwarded to |
+| `enabled` | `false` | `true` | Whether or not the Kube ApiServer job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment |
+| `namespace` | `false` | `default` | The namespaces to look for targets in |
+| `service` | `false` | `kubernetes` | The label to use for the selector |
+| `port_name` | `false` | `https` | The value of the label for the selector |
+| `job_label` | `false` | `integrations/kubernetes/kube-apiserver` | The job label to add for all kube-apiserver metric |
+| `drop_metrics` | `false` | [see module](./kube-apiserver.river#L153) | A regex of metrics to drop |
+| `drop_les` | `false` | [see module](./kube-apiserver.river#163) | Regex of metric les label values to drop |
+| `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
+| `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `clustering` | `false` | `false` | Whether or not clustering should be enabled |
+
+---
+
+### Kube Probes
+
+| Argument | Required | Default | Description |
+| :------- | :------- | :-------| :---------- |
+| `forward_to` | `true` | _NA_ | Must be a list(MetricsReceiver) where collected logs should be forwarded to |
+| `enabled` | `false` | `true` | Whether or not the Kube Probes job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment |
+| `job_label` | `false` | `integrations/kubernetes/kube-probes` | The job label to add for all kube-probe metric |
+| `keep_metrics` | `false` | [see module](./kube-probes.river#L117) | A regex of metrics to keep |
+| `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
+| `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `clustering` | `false` | `false` | Whether or not clustering should be enabled |
+
+---
+
+### Kube Proxy
+
+| Argument | Required | Default | Description |
+| :------- | :------- | :-------| :---------- |
+| `forward_to` | `true` | _NA_ | Must be a list(MetricsReceiver) where collected logs should be forwarded to |
+| `enabled` | `false` | `true` | Whether or not the Kube Proxy job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment |
+| `namespace` | `false` | `kube-system` | The namespaces to look for targets in |
+| `selectors` | `false` | `["component=kube-proxy"]` | The label selectors to use to find matching targets |
+| `port` | `false` | `10249` | The port to scrape kube-proxy metrics on |
+| `job_label` | `false` | `integrations/kubernetes/kube-proxy` | The job label to add for all kube-apiserver metric |
+| `keep_metrics` | `false` | [see module](./kube-proxy.river#L124) | A regex of metrics to drop |
+| `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
+| `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `clustering` | `false` | `false` | Whether or not clustering should be enabled |
+
+---
+
+### Kube Resource
+
+| Argument | Required | Default | Description |
+| :------- | :------- | :-------| :---------- |
+| `forward_to` | `true` | _NA_ | Must be a list(MetricsReceiver) where collected logs should be forwarded to |
+| `enabled` | `false` | `true` | Whether or not the Kube Resources job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment |
+| `job_label` | `false` | `integrations/kubernetes/kube-resources` | The job label to add for all metrics |
+| `keep_metrics` | `false` | [see module](./kube-resource.river#L117) | A regex of metrics to keep |
+| `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
+| `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `clustering` | `false` | `false` | Whether or not clustering should be enabled |
+
+---
+
+### Kube State Metrics
+
+| Argument | Required | Default | Description |
+| :------- | :------- | :-------| :---------- |
+| `forward_to` | `true` | _NA_ | Must be a list(MetricsReceiver) where collected logs should be forwarded to |
+| `enabled` | `false` | `true` | Whether or not the kube-state-metrics job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment |
+| `namespaces` | `false` | `[]` | The namespaces to look for targets in (`[]` is all namespaces) |
+| `selectors` | `false` | `["app.kubernetes.io/name=kube-state-metrics"]` | The label selectors to use to find matching targets |
+| `port_name` | `false` | `http-metrics` | The of the port to scrape metrics from |
+| `job_label` | `false` | `integrations/kubenetes/kube-state-metrics` | The job label to add for all metrics |
+| `keep_metrics` | `false` | [see module](./kube-state-metrics.river#L127) | A regex of metrics to keep |
+| `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
+| `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `clustering` | `false` | `false` | Whether or not clustering should be enabled |
+
+---
+
+### Kubelet
+
+| Argument | Required | Default | Description |
+| :------- | :------- | :-------| :---------- |
+| `forward_to` | `true` | _NA_ | Must be a list(MetricsReceiver) where collected logs should be forwarded to |
+| `enabled` | `false` | `true` | Whether or not the Kubelet job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment |
+| `job_label` | `false` | `integrations/kubernetes/kubelet` | The job label to add for all kube-probe metric |
+| `keep_metrics` | `false` | [see module](./kubelet.river#L116) | A regex of metrics to keep |
+| `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
+| `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `clustering` | `false` | `false` | Whether or not clustering should be enabled |
+
+---
+
+### Loki
+
+| Argument | Required | Default | Description |
+| :------- | :------- | :-------| :---------- |
+| `forward_to` | `true` | _NA_ | Must be a list(MetricsReceiver) where collected logs should be forwarded to |
+| `enabled` | `false` | `true` | Whether or not the Loki job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment |
+| `namespaces` | `false` | `[]` | The namespaces to look for targets in (`[]` is all namespaces) |
+| `selectors` | `false` | `["app.kubernetes.io/name=loki"]` | The label selectors to use to find matching targets |
+| `port_name` | `false` | `http-metrics` | The of the port to scrape metrics from |
+| `job_label` | `false` | `integrations/loki` | The job label to add for all metrics |
+| `keep_metrics` | `false` | [see module](./loki.river#L186) | A regex of metrics to keep |
+| `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
+| `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `clustering` | `false` | `false` | Whether or not clustering should be enabled |
+
+---
+
+### Memcached
+
+| Argument | Required | Default | Description |
+| :------- | :------- | :-------| :---------- |
+| `forward_to` | `true` | _NA_ | Must be a list(MetricsReceiver) where collected logs should be forwarded to |
+| `enabled` | `false` | `true` | Whether or not the Memcached job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment |
+| `namespaces` | `false` | `[]` | The namespaces to look for targets in (`[]` is all namespaces) |
+| `selectors` | `false` | `["app.kubernetes.io/name=memcached"]` | The label selectors to use to find matching targets |
+| `port_name` | `false` | `metrics` | The of the port to scrape metrics from |
+| `job_label` | `false` | `integrations/memcached` | The job label to add for all metrics |
+| `keep_metrics` | `false` | [see module](./memcached.river#L170) | A regex of metrics to keep |
+| `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
+| `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `clustering` | `false` | `false` | Whether or not clustering should be enabled |
+
+___
+
+### Mimir
+
+| Argument | Required | Default | Description |
+| :------- | :------- | :-------| :---------- |
+| `forward_to` | `true` | _NA_ | Must be a list(MetricsReceiver) where collected logs should be forwarded to |
+| `enabled` | `false` | `true` | Whether or not the Mimir job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment |
+| `namespaces` | `false` | `[]` | The namespaces to look for targets in (`[]` is all namespaces) |
+| `selectors` | `false` | `["app.kubernetes.io/name=mimir"]` | The label selectors to use to find matching targets |
+| `port_name` | `false` | `http-metrics` | The of the port to scrape metrics from |
+| `job_label` | `false` | `integrations/mimir` | The job label to add for all metrics |
+| `keep_metrics` | `false` | [see module](./mimir.river#L186) | A regex of metrics to keep |
+| `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
+| `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `clustering` | `false` | `false` | Whether or not clustering should be enabled |
+
+---
+
+### Node Exporter
+
+| Argument | Required | Default | Description |
+| :------- | :------- | :-------| :---------- |
+| `forward_to` | `true` | _NA_ | Must be a list(MetricsReceiver) where collected logs should be forwarded to |
+| `enabled` | `false` | `true` | Whether or not the Node Exporter job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment |
+| `namespaces` | `false` | `[]` | The namespaces to look for targets in (`[]` is all namespaces) |
+| `selectors` | `false` | `["app.kubernetes.io/name=prometheus-node-exporter"]` | The label selectors to use to find matching targets |
+| `port_name` | `false` | `metrics` | The of the port to scrape metrics from |
+| `job_label` | `false` | `integrations/node_exporter` | The job label to add for all metrics |
+| `keep_metrics` | `false` | [see module](./node-exporter.river#L141) | A regex of metrics to keep |
+| `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
+| `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `clustering` | `false` | `false` | Whether or not clustering should be enabled |
+
+---
+
+### OpenCost
+
+| Argument | Required | Default | Description |
+| :------- | :------- | :-------| :---------- |
+| `forward_to` | `true` | _NA_ | Must be a list(MetricsReceiver) where collected logs should be forwarded to |
+| `enabled` | `false` | `true` | Whether or not the OpenCost job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment |
+| `namespaces` | `false` | `[]` | The namespaces to look for targets in (`[]` is all namespaces) |
+| `selectors` | `false` | `["app.kubernetes.io/name=opencost"]` | The label selectors to use to find matching targets |
+| `port_name` | `false` | `http` | The of the port to scrape metrics from |
+| `job_label` | `false` | `integrations/kubernetes/opencost` | The job label to add for all metrics |
+| `keep_metrics` | `false` | [see module](./opencost.river#L123) | A regex of metrics to keep |
+| `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
+| `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `clustering` | `false` | `false` | Whether or not clustering should be enabled |
+
+---
+
+### Prometheus Operator
+
+| Argument | Required | Default | Description |
+| :------- | :------- | :-------| :---------- |
+| `forward_to` | `true` | _NA_ | Must be a list(MetricsReceiver) where collected logs should be forwarded to |
+| `namespaces` | `false` | `[]` | List of namespaces to search for prometheus operator resources in |
+| `servicemonitor_namespaces` | `false` | `[]` | List of namespaces to search for just servicemonitors resources in |
+| `podmonitor_namespaces` | `false` | `[]` | List of namespaces to search for just podmonitors resources in |
+| `probe_namespaces` | `false` | `[]` | List of namespaces to search for just probes resources in |
+| `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
+| `clustering` | `false` | `false` | Whether or not clustering should be enabled |
+
+---
+
+### Tempo
+
+| Argument | Required | Default | Description |
+| :------- | :------- | :-------| :---------- |
+| `forward_to` | `true` | _NA_ | Must be a list(MetricsReceiver) where collected logs should be forwarded to |
+| `enabled` | `false` | `true` | Whether or not the Tempo job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment |
+| `namespaces` | `false` | `[]` | The namespaces to look for targets in (`[]` is all namespaces) |
+| `selectors` | `false` | `["app.kubernetes.io/name=tempo"]` | The label selectors to use to find matching targets |
+| `port_name` | `false` | `http-metrics` | The of the port to scrape metrics from |
+| `job_label` | `false` | `integrations/tempo` | The job label to add for all metrics |
+| `keep_metrics` | `false` | [see module](./tempo.river#L183) | A regex of metrics to keep |
+| `scrape_interval` | `false` | `60s` | How often to scrape metrics from the targets |
+| `scrape_timeout` | `false` | `10s` | How long before a scrape times out |
+| `max_cache_size` | `false` | `100000` | The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient |
+| `clustering` | `false` | `false` | Whether or not clustering should be enabled |

--- a/modules/kubernetes/metrics/jobs/agent.river
+++ b/modules/kubernetes/metrics/jobs/agent.river
@@ -1,0 +1,238 @@
+/*
+Module: job-agent
+Description: Scrapes grafana agent
+
+Note: Every argument except for "forward_to" is optional, and does have a defined default value.  However, the values for these
+      arguments are not defined using the default = " ... " argument syntax, but rather using the coalesce(argument.value, " ... ").
+      This is because if the argument passed in from another consuming module is set to null, the default = " ... " syntax will
+      does not override the value passed in, where coalesce() will return the first non-null value.
+*/
+argument "forward_to" {
+  comment = "Must be a list(MetricsReceiver) where collected logs should be forwarded to"
+}
+
+argument "enabled" {
+  comment = "Whether or not the grafana-agent job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment"
+  optional = true
+}
+
+argument "namespaces" {
+  comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+  optional = true
+}
+
+argument "selectors" {
+  // Docs: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=grafana-agent\"])"
+  optional = true
+}
+
+argument "port_name" {
+  comment = "The of the port to scrape metrics from (default: http-metrics)"
+  optional = true
+}
+
+argument "job_label" {
+  comment = "The job label to add for all grafana-agent metric (default: integrations/agent)"
+  optional = true
+}
+
+argument "keep_metrics" {
+  comment = "A regex of metrics to keep (default: see below)"
+  optional = true
+}
+
+argument "scrape_interval" {
+  comment = "How often to scrape metrics from the targets (default: 60s)"
+  optional = true
+}
+
+argument "scrape_timeout" {
+  comment = "How long before a scrape times out (default: 10s)"
+  optional = true
+}
+
+argument "max_cache_size" {
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  optional = true
+}
+
+argument "clustering" {
+  // Docs: https://grafana.com/docs/agent/latest/flow/concepts/clustering/
+  comment = "Whether or not clustering should be enabled (default: false)"
+  optional = true
+}
+
+// grafana agent service discovery for all of the pods in the grafana agent daemonset
+discovery.kubernetes "agent" {
+  role = "pod"
+
+  selectors {
+    role = "pod"
+    label = join(coalesce(argument.selectors.value, ["app.kubernetes.io/name=grafana-agent"]), ",")
+  }
+
+  namespaces {
+    names = coalesce(argument.namespaces.value, [])
+  }
+}
+
+// grafana agent relabelings (pre-scrape)
+discovery.relabel "agent" {
+  targets = discovery.kubernetes.agent.targets
+
+  // drop all targets if enabled is false
+  rule {
+    target_label = "__enabled"
+    replacement = format("%s", coalesce(argument.enabled.value, "true"))
+  }
+  rule {
+    source_labels = ["__enabled"]
+    regex = "false"
+    action = "drop"
+  }
+
+  // keep only the specified metrics port name, and pods that are Running and ready
+  rule {
+    source_labels = [
+      "__meta_kubernetes_pod_container_port_name",
+      "__meta_kubernetes_pod_phase",
+      "__meta_kubernetes_pod_ready",
+    ]
+    separator = "@"
+    regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true"
+    action = "keep"
+  }
+
+  // set the namespace label
+  rule {
+    source_labels = ["__meta_kubernetes_namespace"]
+    target_label  = "namespace"
+  }
+
+  // set the pod label
+  rule {
+    source_labels = ["__meta_kubernetes_pod_name"]
+    target_label  = "pod"
+  }
+
+  // set the container label
+  rule {
+    source_labels = ["__meta_kubernetes_pod_container_name"]
+    target_label  = "container"
+  }
+
+  // set a controller label
+  rule {
+    source_labels = [
+      "__meta_kubernetes_pod_controller_kind",
+      "__meta_kubernetes_pod_controller_name",
+    ]
+    separator = "/"
+    target_label  = "controller"
+  }
+
+  // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+      "__meta_kubernetes_pod_label_k8s_app",
+      "__meta_kubernetes_pod_label_app",
+    ]
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "app"
+  }
+}
+
+// grafana agent scrape job
+prometheus.scrape "agent" {
+  job_name = coalesce(argument.job_label.value, "integrations/agent")
+  forward_to = [prometheus.relabel.agent.receiver]
+  targets = discovery.relabel.agent.output
+  scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+  scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+
+  clustering {
+    enabled = coalesce(argument.clustering.value, false)
+  }
+}
+
+// grafana-agent metric relabelings (post-scrape)
+prometheus.relabel "agent" {
+  forward_to = argument.forward_to.value
+  max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+  // keep only metrics that match the keep_metrics regex
+  rule {
+    source_labels = ["__name__"]
+    regex = coalesce(argument.keep_metrics.value, "(up|log_.+|(agent_(build_info|tcp_connections|wal_(samples_appended_total|storage_active_series))|go_(gc_duration_seconds_count|goroutines|memstats_heap_inuse_bytes)|process_(cpu_seconds_total|start_time_seconds)|prometheus_(remote_storage_(enqueue_retries_total|highest_timestamp_in_seconds|queue_highest_sent_timestamp_seconds|samples_(dropped_total|failed_total|pending|retried_total|total)|sent_batch_duration_seconds_(bucket|count|sum)|shard_(capacity|s(_desired|_max|_min))|succeeded_samples_total)|sd_discovered_targets|target_(interval_length_seconds_(count|sum)|scrapes_(exceeded_sample_limit_total|sample_(duplicate_timestamp_total|out_of_bounds_total|out_of_order_total)))|target_sync_length_seconds_sum|wal_watcher_current_segment)|traces_(exporter_send_failed_spans|exporter_sent_spans|loadbalancer_(backend_outcome|num_backends)|receiver_(accepted_spans|refused_spans))))")
+    action = "keep"
+  }
+
+  // remove the component_id label from any metric that starts with log_bytes or log_lines, these are custom metrics that are generated
+  // as part of the log annotation modules in this repo
+  rule {
+    action = "replace"
+    source_labels = ["__name__"]
+    regex = "^log_(bytes|lines).+"
+    replacement = ""
+    target_label = "component_id"
+  }
+
+  // set the namespace label to that of the exported_namespace
+  rule {
+    action = "replace"
+    source_labels = ["__name__", "exported_namespace"]
+    separator = "@"
+    regex = "^log_(bytes|lines).+@(.+)"
+    replacement = "$2"
+    target_label = "namespace"
+  }
+
+  // set the pod label to that of the exported_pod
+  rule {
+    action = "replace"
+    source_labels = ["__name__", "exported_pod"]
+    separator = "@"
+    regex = "^log_(bytes|lines).+@(.+)"
+    replacement = "$2"
+    target_label = "pod"
+  }
+
+  // set the container label to that of the exported_container
+  rule {
+    action = "replace"
+    source_labels = ["__name__", "exported_container"]
+    separator = "@"
+    regex = "^log_(bytes|lines).+@(.+)"
+    replacement = "$2"
+    target_label = "container"
+  }
+
+  // set the job label to that of the exported_job
+  rule {
+    action = "replace"
+    source_labels = ["__name__", "exported_job"]
+    separator = "@"
+    regex = "^log_(bytes|lines).+@(.+)"
+    replacement = "$2"
+    target_label = "job"
+  }
+
+  // set the instance label to that of the exported_instance
+  rule {
+    action = "replace"
+    source_labels = ["__name__", "exported_instance"]
+    separator = "@"
+    regex = "^log_(bytes|lines).+@(.+)"
+    replacement = "$2"
+    target_label = "instance"
+  }
+
+  rule {
+    action = "labeldrop"
+    regex = "exported_(namespace|pod|container|job|instance)"
+  }
+}

--- a/modules/kubernetes/metrics/jobs/agent.river
+++ b/modules/kubernetes/metrics/jobs/agent.river
@@ -53,7 +53,7 @@ argument "scrape_timeout" {
 }
 
 argument "max_cache_size" {
-  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
   optional = true
 }
 

--- a/modules/kubernetes/metrics/jobs/annotations-probe.river
+++ b/modules/kubernetes/metrics/jobs/annotations-probe.river
@@ -119,7 +119,7 @@ argument "scrape_timeout" {
 }
 
 argument "max_cache_size" {
-  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
   optional = true
 }
 

--- a/modules/kubernetes/metrics/jobs/annotations-probe.river
+++ b/modules/kubernetes/metrics/jobs/annotations-probe.river
@@ -1,0 +1,463 @@
+/*
+Module: job-agent
+Description: Scrapes grafana agent
+
+Note: Every argument except for "forward_to" and "role" is optional, and does have a defined default value.  However, the values for these
+      arguments are not defined using the default = " ... " argument syntax, but rather using the coalesce(argument.value, " ... ").
+      This is because if the argument passed in from another consuming module is set to null, the default = " ... " syntax will
+      does not override the value passed in, where coalesce() will return the first non-null value.
+
+Kubernetes Service Auto-Probing
+------------------------------------------------------------------------------------------------------------------------------------
+This module is meant to be used to automatically scrape targets based on a certain role and set of annotations.  This module can be consumed
+multiple times with different roles.  The supported roles are:
+
+  - service
+  - ingress
+
+Each port attached to an service is an eligible target, oftentimes service will have multiple ports.
+There may be instances when you want to probe all ports or some ports and not others. To support this
+the following annotations are available:
+
+only probe services with probe set to true, this can be single valued i.e. probe all ports for
+the service:
+
+probes.grafana.com/probe: true
+
+the default probing scheme is "", this can be specified as a single value which would override,
+if using HTTP prober specify "http" or "https":
+
+probes.grafana.com/scheme: https
+
+the default path to probe is /metrics, this can be specified as a single value which would override,
+the probe path being used for all ports attached to the service:
+
+probes.grafana.com/path: /metrics/some_path
+
+the default module to use for probing the default value is "unknown" as the modules are defined are in your blackbox exporter
+configuration file, this can be specified as a single value which would override, the probe module being used for all ports
+attached to the service:
+
+probes.grafana.com/module: http_2xx
+
+the default port to probe is the service port, this can be specified as a single value which would
+override the probe port being used for all ports attached to the service, note that even if aan service had
+multiple targets, the relabel_config targets are deduped before scraping:
+
+probes.grafana.com/port: 8080
+
+the value to set for the job label, by default this would be "integrations/blackbox_exporter" if not specified:
+
+probes.grafana.com/job: blackbox-exporter
+
+the default interval to probe is 1m, this can be specified as a single value which would override,
+the probe interval being used for all ports attached to the service:
+
+probes.grafana.com/interval: 5m
+
+the default timeout for scraping is 10s, this can be specified as a single value which would override,
+the probe interval being used for all ports attached to the service:
+
+probes.grafana.com/timeout: 30s
+*/
+argument "forward_to" {
+  comment = "Must be a list(MetricsReceiver) where collected logs should be forwarded to"
+}
+
+argument "role" {
+  comment = "The role to use when looking for targets to scrape via annotations, can be: service or ingress (default: service)"
+}
+
+argument "blackbox_url" {
+  comment = "The address of the blackbox exporter to use (without the protocol), only the hostname and port i.e. blackbox-prometheus-blackbox-exporter.default.svc.cluster.local:9115"
+}
+
+argument "namespaces" {
+  comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+  optional = true
+}
+
+argument "selectors" {
+  // see: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  comment = "The label selectors to use to find matching annotation targets (default: [] is all targets)"
+  optional = true
+}
+
+argument "annotation" {
+  // Docs: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  // k8s selectors d not support a logical OR, if multiple types of annotations are needed, this module should be invoked multiple times
+  // i.e. probes.grafana.com, then again for prometheus.io
+  comment = "The annotation namespace to use (default: probes.grafana.com)"
+  default = "probes.grafana.com"
+  optional = true
+}
+
+argument "tenant" {
+  comment = "The tenant to write metrics to.  This does not have to be the tenantId, this is the value to look for in the probes.grafana.com/tenant annotation, and this can be a regex."
+  optional = true
+  default = ".*"
+}
+
+argument "keep_metrics" {
+  comment = "A regex of metrics to keep (default: (.+))"
+  optional = true
+}
+
+argument "drop_metrics" {
+  comment = "A regex of metrics to drop (default: \"\")"
+  optional = true
+}
+
+argument "scrape_interval" {
+  comment = "How often to scrape metrics from the targets (default: 60s)"
+  optional = true
+}
+
+argument "scrape_timeout" {
+  comment = "How long before a scrape times out (default: 10s)"
+  optional = true
+}
+
+argument "max_cache_size" {
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  optional = true
+}
+
+argument "clustering" {
+  // Docs: https://grafana.com/docs/agent/latest/flow/concepts/clustering/
+  comment = "Whether or not clustering should be enabled (default: false)"
+  optional = true
+}
+
+/*
+  Hidden Arguments
+  These arguments are used to set reusable variables to avoid repeating logic
+*/
+argument "__sd_annotation" {
+  optional = true
+  comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
+  default = replace(replace(replace(coalesce(argument.annotation.value, "probes.grafana.com"),".", "_"),"/", "_"),"-", "_")
+}
+
+// annotations service discovery
+discovery.kubernetes "probes" {
+  role = coalesce(argument.role.value, "service")
+
+  selectors {
+    role = coalesce(argument.role.value, "service")
+    label = join(coalesce(argument.selectors.value, []), ",")
+  }
+
+  namespaces {
+    names = coalesce(argument.namespaces.value, [])
+  }
+}
+
+discovery.relabel "probes" {
+  targets = discovery.kubernetes.probes.targets
+
+  /****************************************************************************************************************
+   * Handle Targets to Keep or Drop
+   ****************************************************************************************************************/
+  // allow resources to declare they should be probed or not
+  // Example Annotation:
+  //   probes.grafana.com/probe: false
+  //
+  // the label prometheus.io/service-monitor: "false" is a common label for headless services, if it is set to false,
+  // do not probe the target
+  rule {
+    action = "keep"
+    source_labels = [
+      "__meta_kubernetes_" + argument.role.value + "_annotation_" + argument.__sd_annotation.value + "_probe",
+      "__meta_kubernetes_" + argument.role.value + "_label_prometheus_io_service_monitor",
+    ]
+    regex = "^true;(|true)$"
+  }
+
+  // only keep targets where the pod is running or the pod_phase is empty and is not an init container.  This will only exist for role="pod" or
+  // potentially role="endpoints", if it is a service the value is empty and thus allowed to pass, if it is an endpoint but not associated to a
+  // pod but rather a static IP or hostname, that could be outside of kubernetes allow endpoints to declare what tenant their metrics should be
+  // written to
+  rule {
+    action = "keep"
+    source_labels = ["__meta_kubernetes_pod_phase"]
+    regex = "^(?i)(Running|)$"
+  }
+  rule {
+    action = "keep"
+    source_labels = ["__meta_kubernetes_pod_ready"]
+    regex = "^(true|)$"
+  }
+  // if the container is an init container, drop it
+  rule {
+    action = "drop"
+    source_labels = ["__meta_kubernetes_pod_container_init"]
+    regex = "^(true)$"
+  }
+
+  // allow resources to declare their metrics the tenant their metrics should be sent to,
+  // Example Annotation:
+  //   probes.grafana.com/tenant: primary
+  //
+  // Note: This does not necessarily have to be the actual tenantId, it can be a friendly name as well that is simply used
+  //       to determine if the metrics should be gathered for the current tenant
+  rule {
+    action = "keep"
+    source_labels = [
+      "__meta_kubernetes_" + argument.role.value + "_annotation_" + argument.__sd_annotation.value + "_tenant",
+    ]
+    regex = "^(" + argument.tenant.value + ")$"
+  }
+
+  /****************************************************************************************************************
+   * Handle Setting Scrape Metadata i.e. path, port, interval etc.
+   ****************************************************************************************************************/
+  // allow resources to declare the protocol to use when collecting metrics, the default value is "http", this is the scheme
+  // of the target address, not the scheme to use for blackbox exporter
+  // Example Annotation:
+  //   probes.grafana.com/scheme: http
+  rule {
+    action = "replace"
+    replacement = "http"
+    target_label = "__scheme__"
+  }
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_" + argument.role.value + "_annotation_" + argument.__sd_annotation.value + "_scheme",
+      "__meta_kubernetes_ingress_scheme", // this would only exist for ingresses and can be used instead of setting the annotation
+    ]
+    separator = ";"
+    regex = "^(?:;*)?(https?).*$"
+    replacement = "$1"
+    target_label = "__scheme__"
+  }
+
+  // allow resources to declare the port to use when collecting metrics, the default value is the discovered port from
+  // Example Annotation:
+  //   probes.grafana.com/port: 9090
+  rule {
+    action = "replace"
+    source_labels = [
+      "__address__",
+      "__meta_kubernetes_" + argument.role.value + "_annotation_" + argument.__sd_annotation.value + "_port",
+      "__meta_kubernetes_" + argument.role.value + "_port_number",
+    ]
+    separator = ";"
+    regex = "^([^:]+)(?::\\d+)?(?:;*)?([^;]+).*"
+    replacement = "$1:$2"
+    target_label = "__address__"
+  }
+
+  // allow resources to declare their the path to use when collecting their metrics, the default value is "/metrics",
+  // Example Annotation:
+  //   probes.grafana.com/path: /metrics/foo
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_" + argument.role.value + "_annotation_" + argument.__sd_annotation.value + "_path",
+      "__meta_kubernetes_ingress_path", // this would only exist for ingresses and can be used instead of setting the annotation
+    ]
+    separator = ";"
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "__metrics_path__"
+  }
+
+  // set the target address to probe
+  rule {
+    action = "replace"
+    source_labels = [
+      "__scheme__",
+      "__address__",
+      "__metrics_path__",
+    ]
+    separator = ";"
+    regex = "(.*);(.+);(.+)"
+    replacement = "${1}://${2}${3}"
+    target_label = "__param_target"
+  }
+
+  // allow resources to declare their the module to use when probing, the default value is "unknown",
+  // Example Annotation:
+  //   probes.grafana.com/module: http_2xx
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_" + argument.role.value + "_annotation_" + argument.__sd_annotation.value + "_module",
+    ]
+    separator = ";"
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "__param_module"
+  }
+
+  // allow resources to declare how often their metrics should be collected, the default value is 1m,
+  // the following duration formats are supported (s|m|ms|h|d):
+  // Example Annotation:
+  //   probes.grafana.com/interval: 5m
+  rule {
+    action = "replace"
+    replacement = coalesce(argument.scrape_interval.value, "60s")
+    target_label = "__scrape_interval__"
+  }
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_" + argument.role.value + "_annotation_" + argument.__sd_annotation.value + "_interval",
+    ]
+    separator = ";"
+    regex = "^(?:;*)?(\\d+(s|m|ms|h|d)).*$"
+    replacement = "$1"
+    target_label = "__scrape_interval__"
+  }
+
+  // allow resources to declare the timeout of the scrape request, the default value is 10s,
+  // the following duration formats are supported (s|m|ms|h|d):
+  // Example Annotation:
+  //   probes.grafana.com/timeout: 30s
+  rule {
+    action = "replace"
+    replacement = coalesce(argument.scrape_timeout.value, "10s")
+    target_label = "__scrape_timeout__"
+  }
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_" + argument.role.value + "_annotation_" + argument.__sd_annotation.value + "_timeout",
+    ]
+    separator = ";"
+    regex = "^(?:;*)?(\\d+(s|m|ms|h|d)).*$"
+    replacement = "$1"
+    target_label = "__scrape_timeout__"
+  }
+
+  /****************************************************************************************************************
+   * Handle Setting Common Labels
+   ****************************************************************************************************************/
+  // set the instance label to the target
+  rule {
+    action = "replace"
+    source_labels = ["__param_target"]
+    target_label = "instance"
+  }
+
+  // ensure the __metrics_path is set to /probe
+  rule{
+    action = "replace"
+    replacement = "/probe"
+    target_label = "__metrics_path__"
+  }
+
+  // set the __address__ to send the scrape request to be the probing exporter service address that has been deployed
+  rule{
+    action = "replace"
+    replacement = argument.blackbox_url.value
+    target_label = "__address__"
+  }
+
+  // set the namespace label
+  rule {
+    action = "replace"
+    source_labels = ["__meta_kubernetes_namespace"]
+    target_label = "namespace"
+  }
+
+  // set the target name label i.e. service name, ingress name, etc.
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_" + argument.role.value + "_name",
+    ]
+    separator = ";"
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = argument.role.value
+  }
+
+  // set a default job label to be the namespace/service_name or namespace/ingress_name
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_namespace",
+      argument.role.value,
+    ]
+    separator = ";"
+    regex = "^([^;]+)(?:;*)?([^;]+).*$"
+    replacement = "$1/$2"
+    target_label = "job"
+  }
+
+  // allow resources to declare their the job label value to use when collecting their metrics, the default value is "",
+  // Example Annotation:
+  //   probes.grafana.com/job: my-service/ready-probe
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_" + argument.role.value + "_annotation_" + argument.__sd_annotation.value + "_job",
+    ]
+    separator = ";"
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "job"
+  }
+
+  // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:"
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_" + argument.role.value + "_label_app_kubernetes_io_name",
+      "__meta_kubernetes_" + argument.role.value + "_label_k8s_app",
+      "__meta_kubernetes_" + argument.role.value + "_label_app",
+    ]
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "app"
+  }
+
+  // set the app component if specified as metadata labels "component:" or "app.kubernetes.io/component:"
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_" + argument.role.value + "_label_app_kubernetes_io_component",
+      "__meta_kubernetes_" + argument.role.value + "_label_component",
+    ]
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "component"
+  }
+
+}
+
+// scrape http only targtets
+prometheus.scrape "probes" {
+  job_name = "annotation-probe-http"
+  forward_to = [prometheus.relabel.probes.receiver]
+  targets = discovery.relabel.probes.output
+  scheme = "http"
+  scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+  scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+
+  clustering {
+    enabled = coalesce(argument.clustering.value, false)
+  }
+}
+
+// perform generic relabeling using keep_metrics and drop_metrics
+prometheus.relabel "probes" {
+  forward_to = argument.forward_to.value
+
+  // keep only metrics that match the keep_metrics regex
+  rule {
+    action = "keep"
+    source_labels = ["__name__"]
+    regex = coalesce(argument.keep_metrics.value, "(.+)")
+  }
+
+  // drop metrics that match the drop_metrics regex
+  rule {
+    action = "drop"
+    source_labels = ["__name__"]
+    regex = coalesce(argument.drop_metrics.value, "")
+  }
+}

--- a/modules/kubernetes/metrics/jobs/annotations-scrape.river
+++ b/modules/kubernetes/metrics/jobs/annotations-scrape.river
@@ -1,0 +1,572 @@
+/*
+Module: job-annotation-scrape
+Description: Scrapes targets for metrics based on annotations
+
+Note: Every argument except for "forward_to" and "role" is optional, and does have a defined default value.  However, the values for these
+      arguments are not defined using the default = " ... " argument syntax, but rather using the coalesce(argument.value, " ... ").
+      This is because if the argument passed in from another consuming module is set to null, the default = " ... " syntax will
+      does not override the value passed in, where coalesce() will return the first non-null value.
+
+Kubernetes Annotation Auto-Scraping
+------------------------------------------------------------------------------------------------------------------------------------
+This module is meant to be used to automatically scrape targets based on a certain role and set of annotations.  This module can be consumed
+multiple times with different roles.  The supported roles are:
+
+  - pod
+  - service
+  - endpoints
+
+Typically, if mimicking the behavior of the prometheus-operator, and ServiceMonitor functionality you would use role="endpoints", if
+mimicking the behavior of the PodMonitor functionality you would use role="pod".  It is important to understand that with endpoints,
+the target is typically going to be a pod, and whatever annotations that are set on the service will automatically be propagated to the
+endpoints.  This is why the role "endpoints" is used, because it will scrape the pod, but also consider the service annotations.  Using
+role="endpoints", which scrape each endpoint associated to the service.  If role="service" is used, it will only scrape the service, only
+hitting one of the endpoints associated to the service.
+
+This is where you must consider your scraping strategy, for example if you scrape a service like "kube-state-metrics" using
+role="endpoints" you should only have a single replica of the kube-state-metrics pod, if you have multiple replicas, you should use
+role="service" or a separate non-annotation job completely.  Scraping a service instead of endpoints, is typically a rare use case, but
+it is supported.
+
+There are other considerations for using annotation based scraping as well, which is metric relabeling rules that happen post scrape.  If
+you have a target that you want to apply a bunch of relabelings to or a very large metrics response payload, performance wise it will be
+better to have a separate job for that target, rather than using use annotations.  As every targert will go through the ssame relabeling.
+Typical deployment strategies/options would be:
+
+Option #1 (recommended):
+  - Annotation Scraping for role="endpoints"
+  - Separate Jobs for specific service scrapes (i.e. kube-state-metrics, node-exporter, etc.) or large metric payloads
+  - Separate Jobs for K8s API scraping (i.e. cadvisor, kube-apiserver, kube-scheduler, etc.)
+
+Option #2:
+  - Annotation Scraping for role="pod"
+  - Annotation Scraping for role="service"  (i.e. kube-state-metrics, node-exporter, etc.)
+  - Separate Jobs for specific use cases or large metric payloads
+  - Separate Jobs for K8s API scraping (i.e. cadvisor, kube-apiserver, kube-scheduler, etc.)
+
+At no point should you use role="endpoints" and role="pod" together, as this will result in duplicate targets being scraped, thus
+generating duplicate metrics.  If you want to scrape both the pod and the service, use Option #2.
+
+Each port attached to an service/pod/endpoint is an eligible target, oftentimes it will have multiple ports.
+There may be instances when you want to scrape all ports or some ports and not others. To support this
+the following annotations are available:
+
+  metrics.agent.grafana.com/scrape: true
+
+the default scraping scheme is http, this can be specified as a single value which would override, the schema being used for all
+ports attached to the target:
+
+  metrics.agent.grafana.com/scheme: https
+
+the default path to scrape is /metrics, this can be specified as a single value which would override, the scrape path being used
+for all ports attached to the target:
+
+  metrics.agent.grafana.com/path: /metrics/some_path
+
+the default port to scrape is the target port, this can be specified as a single value which would override the scrape port being
+used for all ports attached to the target, note that even if aan target had multiple targets, the relabel_config targets are
+deduped before scraping:
+
+  metrics.agent.grafana.com/port: 8080
+
+the default interval to scrape is 1m, this can be specified as a single value which would override, the scrape interval being used
+for all ports attached to the target:
+
+  metrics.agent.grafana.com/interval: 5m
+
+the default timeout for scraping is 10s, this can be specified as a single value which would override, the scrape interval being
+used for all ports attached to the target:
+
+  metrics.agent.grafana.com/timeout: 30s
+
+the default job is namespace/{{ service name }} or namespace/{{ controller_name }} depending on the role, there may be instantces
+in which a different job name is required because of a set of dashboards, rules, etc. to support this there is a job annotation
+which will override the default value:
+
+  metrics.agent.grafana.com/job: integrations/kubernetes/kube-state-metrics
+*/
+argument "forward_to" {
+  comment = "Must be a list(MetricsReceiver) where collected logs should be forwarded to"
+}
+
+argument "role" {
+  comment = "The role to use when looking for targets to scrape via annotations, can be: endpoints, service, pod (default: endpoints)"
+}
+
+argument "namespaces" {
+  comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+  optional = true
+}
+
+argument "selectors" {
+  // see: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  comment = "The label selectors to use to find matching annotation targets (default: [] is all targets)"
+  optional = true
+}
+
+argument "annotation" {
+  // Docs: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  // k8s selectors d not support a logical OR, if multiple types of annotations are needed, this module should be invoked multiple times
+  // i.e. metrics.agent.grafana.com, then again for prometheus.io
+  comment = "The annotation namespace to use (default: metrics.agent.grafana.com)"
+  default = "metrics.agent.grafana.com"
+  optional = true
+}
+
+argument "tenant" {
+  comment = "The tenant to write metrics to.  This does not have to be the tenantId, this is the value to look for in the logs.agent.grafana.com/tenant annotation, and this can be a regex."
+  optional = true
+  default = ".*"
+}
+
+argument "keep_metrics" {
+  comment = "A regex of metrics to keep (default: (.+))"
+  optional = true
+}
+
+argument "drop_metrics" {
+  comment = "A regex of metrics to drop (default: \"\")"
+  optional = true
+}
+
+argument "scrape_port_named_metrics" {
+  comment = "Whether or not to automatically scrape endpoints that have a port with 'metrics' in the name"
+  optional = true
+  default = false
+}
+
+argument "scrape_interval" {
+  comment = "How often to scrape metrics from the targets (default: 60s)"
+  optional = true
+}
+
+argument "scrape_timeout" {
+  comment = "How long before a scrape times out (default: 10s)"
+  optional = true
+}
+
+argument "max_cache_size" {
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  optional = true
+}
+
+argument "clustering" {
+  // Docs: https://grafana.com/docs/agent/latest/flow/concepts/clustering/
+  comment = "Whether or not clustering should be enabled (default: false)"
+  optional = true
+}
+
+/*
+  Hidden Arguments
+  These arguments are used to set reusable variables to avoid repeating logic
+*/
+argument "__pod_role" {
+  comment = "Most annotation targets service or pod that is all you want, however if the role is endpoints you want the pod"
+  optional = true
+  default = replace(coalesce(argument.role.value, "endpoints"), "endpoints", "pod")
+}
+
+argument "__service_role" {
+  comment = "Most annotation targets service or pod that is all you want, however if the role is endpoints you we also want to consider service annotations"
+  optional = true
+  default = replace(coalesce(argument.role.value, "endpoints"), "endpoints", "service")
+}
+
+argument "__sd_annotation" {
+  optional = true
+  comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
+  default = replace(replace(replace(coalesce(argument.annotation.value, "metrics.agent.grafana.com"),".", "_"),"/", "_"),"-", "_")
+}
+
+// annotations service discovery
+discovery.kubernetes "annotations" {
+  role = coalesce(argument.role.value, "endpoints")
+
+  selectors {
+    role = coalesce(argument.role.value, "endpoints")
+    label = join(coalesce(argument.selectors.value, []), ",")
+  }
+
+  namespaces {
+    names = coalesce(argument.namespaces.value, [])
+  }
+}
+
+discovery.relabel "annotations" {
+  targets = discovery.kubernetes.annotations.targets
+
+  /****************************************************************************************************************
+   * Handle Targets to Keep or Drop
+   ****************************************************************************************************************/
+  // allow resources to declare their metrics scraped or not
+  // Example Annotation:
+  //   metrics.agent.grafana.com/scrape: false
+  //
+  // the label prometheus.io/service-monitor: "false" is a common label for headless services, when performing endpoint
+  // service discovery, if there is both a load-balanced service and headless service, this can result in duplicate
+  // scrapes if the name of the service is attached as a label.  any targets with this label or annotation set should be dropped
+  rule {
+    action = "replace"
+    replacement = "false"
+    target_label = "__tmp_scrape"
+  }
+
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_" + argument.role.value + "_annotation_" + argument.__sd_annotation.value + "_scrape",
+      "__meta_kubernetes_" + argument.__service_role.value + "_annotation_" + argument.__sd_annotation.value + "_scrape",
+      "__meta_kubernetes_" + argument.role.value + "_label_prometheus_io_service_monitor",
+    ]
+    separator = ";"
+    // only allow empty or true, otherwise defaults to false
+    regex = "^(?:;*)?(true)(;|true)*$"
+    replacement = "$1"
+    target_label = "__tmp_scrape"
+  }
+
+  // add a __tmp_scrape_port_named_metrics from the argument.scrape_port_named_metrics
+  rule {
+    replacement = format("%t", argument.scrape_port_named_metrics.value)
+    target_label = "__tmp_scrape_port_named_metrics"
+  }
+
+  // only keep targets that have scrape: true or "metrics" in the port name if the argument scrape_port_named_metrics
+  rule {
+    action = "keep"
+    source_labels = [
+      "__tmp_scrape",
+      "__tmp_scrape_port_named_metrics",
+      // endpoints is the role and most meta labels started with "endpoints", however the port name is an exception and starts with "endpoint"
+      "__meta_kubernetes_" + replace(coalesce(argument.role.value, "endpoints"), "endpoints", "endpoint") + "_port_name",
+    ]
+    separator = ";"
+    regex = "^(true;.*|(|true);true;(.*metrics.*))$"
+  }
+
+  // only keep targets where the pod is running or the pod_phase is empty and is not an init container.  This will only exist for role="pod" or
+  // potentially role="endpoints", if it is a service the value is empty and thus allowed to pass, if it is an endpoint but not associated to a
+  // pod but rather a static IP or hostname, that could be outside of kubernetes allow endpoints to declare what tenant their metrics should be
+  // written to
+  rule {
+    action = "keep"
+    source_labels = ["__meta_kubernetes_pod_phase"]
+    regex = "^(?i)(Running|)$"
+  }
+  rule {
+    action = "keep"
+    source_labels = ["__meta_kubernetes_pod_ready"]
+    regex = "^(true|)$"
+  }
+  // if the container is an init container, drop it
+  rule {
+    action = "drop"
+    source_labels = ["__meta_kubernetes_pod_container_init"]
+    regex = "^(true)$"
+  }
+
+  // allow resources to declare their metrics the tenant their metrics should be sent to,
+  // Example Annotation:
+  //   metrics.agent.grafana.com/tenant: primary
+  //
+  // Note: This does not necessarily have to be the actual tenantId, it can be a friendly name as well that is simply used
+  //       to determine if the metrics should be gathered for the current tenant
+  rule {
+    action = "keep"
+    source_labels = [
+      "__meta_kubernetes_" + argument.role.value + "_annotation_" + argument.__sd_annotation.value + "_tenant",
+      "__meta_kubernetes_" + argument.__service_role.value + "_annotation_" + argument.__sd_annotation.value + "_tenant",
+    ]
+    regex = "^(" + argument.tenant.value + ")$"
+  }
+
+  /****************************************************************************************************************
+   * Handle Setting Scrape Metadata i.e. path, port, interval etc.
+   ****************************************************************************************************************/
+  // allow resources to declare the protocol to use when collecting metrics, the default value is "http",
+  // Example Annotation:
+  //   metrics.agent.grafana.com/scheme: http
+  rule {
+    action = "replace"
+    replacement = "http"
+    target_label = "__scheme__"
+  }
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_" + argument.role.value + "_annotation_" + argument.__sd_annotation.value + "_scheme",
+      "__meta_kubernetes_" + argument.__service_role.value + "_annotation_" + argument.__sd_annotation.value + "_scheme",
+    ]
+    separator = ";"
+    regex = "^(?:;*)?(https?).*$"
+    replacement = "$1"
+    target_label = "__scheme__"
+  }
+
+  // allow resources to declare the port to use when collecting metrics, the default value is the discovered port from
+  // Example Annotation:
+  //   metrics.agent.grafana.com/port: 9090
+  rule {
+    action = "replace"
+    source_labels = [
+      "__address__",
+      "__meta_kubernetes_" + argument.role.value + "_annotation_" + argument.__sd_annotation.value + "_port",
+      "__meta_kubernetes_" + argument.__service_role.value + "_annotation_" + argument.__sd_annotation.value + "_port",
+    ]
+    separator = ";"
+    regex = "^([^:]+)(?::\\d+)?;(\\d+)$"
+    replacement = "$1:$2"
+    target_label = "__address__"
+  }
+
+  // allow resources to declare their the path to use when collecting their metrics, the default value is "/metrics",
+  // Example Annotation:
+  //   metrics.agent.grafana.com/path: /metrics/foo
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_" + argument.role.value + "_annotation_" + argument.__sd_annotation.value + "_path",
+      "__meta_kubernetes_" + argument.__service_role.value + "_annotation_" + argument.__sd_annotation.value + "_path",
+    ]
+    separator = ";"
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "__metrics_path__"
+  }
+
+  // allow resources to declare how often their metrics should be collected, the default value is 1m,
+  // the following duration formats are supported (s|m|ms|h|d):
+  // Example Annotation:
+  //   metrics.agent.grafana.com/interval: 5m
+  rule {
+    action = "replace"
+    replacement = coalesce(argument.scrape_interval.value, "60s")
+    target_label = "__scrape_interval__"
+  }
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_" + argument.role.value + "_annotation_" + argument.__sd_annotation.value + "_interval",
+      "__meta_kubernetes_" + argument.__service_role.value + "_annotation_" + argument.__sd_annotation.value + "_interval",
+    ]
+    separator = ";"
+    regex = "^(?:;*)?(\\d+(s|m|ms|h|d)).*$"
+    replacement = "$1"
+    target_label = "__scrape_interval__"
+  }
+
+  // allow resources to declare the timeout of the scrape request, the default value is 10s,
+  // the following duration formats are supported (s|m|ms|h|d):
+  // Example Annotation:
+  //   metrics.agent.grafana.com/timeout: 30s
+  rule {
+    action = "replace"
+    replacement = coalesce(argument.scrape_timeout.value, "10s")
+    target_label = "__scrape_timeout__"
+  }
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_" + argument.role.value + "_annotation_" + argument.__sd_annotation.value + "_timeout",
+      "__meta_kubernetes_" + argument.__service_role.value + "_annotation_" + argument.__sd_annotation.value + "_timeout",
+    ]
+    separator = ";"
+    regex = "^(?:;*)?(\\d+(s|m|ms|h|d)).*$"
+    replacement = "$1"
+    target_label = "__scrape_timeout__"
+  }
+
+  /****************************************************************************************************************
+   * Handle Setting Common Labels
+   ****************************************************************************************************************/
+  // set the namespace label
+  rule {
+    action = "replace"
+    source_labels = ["__meta_kubernetes_namespace"]
+    target_label = "namespace"
+  }
+
+  // set the target name label i.e. service name, pod name, etc.
+  // if the role is endpoints, the first valued field is used which would be __meta_kubernetes_pod_name, if the pod name is empty
+  // then the endpoint name would be used
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_" + argument.__pod_role.value + "_name",
+      "__meta_kubernetes_" + argument.role.value + "_name",
+    ]
+    separator = ";"
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = argument.__pod_role.value
+  }
+
+  // set a default job label to be the namespace/pod_controller_name or namespace/service_name
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_namespace",
+      "__meta_kubernetes_pod_controller_name",
+      argument.__pod_role.value,
+    ]
+    separator = ";"
+    regex = "^([^;]+)(?:;*)?([^;]+).*$"
+    replacement = "$1/$2"
+    target_label = "job"
+  }
+
+  // if the controller is a ReplicaSet, drop the hash from the end of the ReplicaSet
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_pod_controller_type",
+      "__meta_kubernetes_namespace",
+      "__meta_kubernetes_pod_controller_name",
+    ]
+    separator = ";"
+    regex = "^(?:ReplicaSet);([^;]+);([^;]+)-.+$"
+    replacement = "$1/$2"
+    target_label = "job"
+  }
+
+  // allow resources to declare their the job label value to use when collecting their metrics, the default value is "",
+  // Example Annotation:
+  //   metrics.agent.grafana.com/job: integrations/kubernetes/cadvisor
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_" + argument.role.value + "_annotation_" + argument.__sd_annotation.value + "_job",
+      "__meta_kubernetes_" + argument.__service_role.value + "_annotation_" + argument.__sd_annotation.value + "_job",
+    ]
+    separator = ";"
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "job"
+  }
+
+  // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:"
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_" + argument.role.value + "_label_app_kubernetes_io_name",
+      "__meta_kubernetes_" + argument.role.value + "_label_k8s_app",
+      "__meta_kubernetes_" + argument.role.value + "_label_app",
+      "__meta_kubernetes_" + argument.__pod_role.value + "_label_app_kubernetes_io_name",
+      "__meta_kubernetes_" + argument.__pod_role.value + "_label_k8s_app",
+      "__meta_kubernetes_" + argument.__pod_role.value + "_label_app",
+      "__meta_kubernetes_" + argument.__service_role.value + "_label_app_kubernetes_io_name",
+      "__meta_kubernetes_" + argument.__service_role.value + "_label_k8s_app",
+      "__meta_kubernetes_" + argument.__service_role.value + "_label_app",
+    ]
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "app"
+  }
+
+  // set the app component if specified as metadata labels "component:" or "app.kubernetes.io/component:"
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_" + argument.role.value + "_label_app_kubernetes_io_component",
+      "__meta_kubernetes_" + argument.role.value + "_label_component",
+      "__meta_kubernetes_" + argument.__pod_role.value + "_label_app_kubernetes_io_component",
+      "__meta_kubernetes_" + argument.__pod_role.value + "_label_component",
+      "__meta_kubernetes_" + argument.__service_role.value + "_label_app_kubernetes_io_component",
+      "__meta_kubernetes_" + argument.__service_role.value + "_label_component",
+    ]
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "component"
+  }
+
+  // add a controller label if the resource is a pod
+  // example: grafana-agent-68nv9 becomes DaemonSet/grafana-agent
+  rule {
+    source_labels = [
+      "__meta_kubernetes_pod_controller_kind",
+      "__meta_kubernetes_pod_controller_name",
+    ]
+    action = "replace"
+    regex = "^(.+);(.+)$"
+    replacement = "$1/$2"
+    target_label = "controller"
+  }
+
+}
+
+// only keep http targets
+discovery.relabel "http_annotations" {
+  targets = discovery.relabel.annotations.output
+
+  rule {
+    action = "keep"
+    source_labels = ["__scheme__"]
+    regex ="http"
+  }
+}
+
+// scrape http only targtets
+prometheus.scrape "http_annotations" {
+  job_name = "annotation-metrics-http"
+  forward_to = [prometheus.relabel.annotations.receiver]
+  targets = discovery.relabel.http_annotations.output
+  scheme = "http"
+  scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+  scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+
+  clustering {
+    enabled = coalesce(argument.clustering.value, false)
+  }
+}
+
+// only keep https targets
+discovery.relabel "https_annotations" {
+  targets = discovery.relabel.annotations.output
+
+  rule {
+    action = "keep"
+    source_labels = ["__scheme__"]
+    regex ="https"
+  }
+}
+
+// scrape https only targtets
+prometheus.scrape "https_annotations" {
+  job_name = "annotation-metrics-https"
+  forward_to = [prometheus.relabel.annotations.receiver]
+  targets = discovery.relabel.https_annotations.output
+  scheme = "https"
+  scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+  scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+  tls_config {
+    ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    insecure_skip_verify = false
+    server_name = "kubernetes"
+  }
+
+  clustering {
+    enabled = coalesce(argument.clustering.value, false)
+  }
+
+}
+
+// perform generic relabeling using keep_metrics and drop_metrics
+prometheus.relabel "annotations" {
+  forward_to = argument.forward_to.value
+
+  // keep only metrics that match the keep_metrics regex
+  rule {
+    action = "keep"
+    source_labels = ["__name__"]
+    regex = coalesce(argument.keep_metrics.value, "(.+)")
+  }
+
+  // drop metrics that match the drop_metrics regex
+  rule {
+    action = "drop"
+    source_labels = ["__name__"]
+    regex = coalesce(argument.drop_metrics.value, "")
+  }
+}

--- a/modules/kubernetes/metrics/jobs/annotations-scrape.river
+++ b/modules/kubernetes/metrics/jobs/annotations-scrape.river
@@ -146,7 +146,7 @@ argument "scrape_timeout" {
 }
 
 argument "max_cache_size" {
-  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
   optional = true
 }
 

--- a/modules/kubernetes/metrics/jobs/cadvisor.river
+++ b/modules/kubernetes/metrics/jobs/cadvisor.river
@@ -37,7 +37,7 @@ argument "scrape_timeout" {
 }
 
 argument "max_cache_size" {
-  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
   optional = true
 }
 

--- a/modules/kubernetes/metrics/jobs/cadvisor.river
+++ b/modules/kubernetes/metrics/jobs/cadvisor.river
@@ -1,0 +1,190 @@
+/*
+Module: job-cadvisor
+Description: Scrapes cAdvisor (Container Advisor Metrics)
+
+Note: Every argument except for "forward_to" is optional, and does have a defined default value.  However, the values for these
+      arguments are not defined using the default = " ... " argument syntax, but rather using the coalesce(argument.value, " ... ").
+      This is because if the argument passed in from another consuming module is set to null, the default = " ... " syntax will
+      does not override the value passed in, where coalesce() will return the first non-null value.
+*/
+argument "forward_to" {
+  comment = "Must be a list(MetricsReceiver) where collected logs should be forwarded to"
+}
+
+argument "enabled" {
+  comment = "Whether or not the cadvisor job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment"
+  optional = true
+}
+
+argument "job_label" {
+  comment = "The job label to add for all cadvisor metrics (default: integrations/kubernetes/cadvisor)"
+  optional = true
+}
+
+argument "keep_metrics" {
+  comment = "A regex of metrics to keep (default: see below)"
+  optional = true
+}
+
+argument "scrape_interval" {
+  comment = "How often to scrape metrics from the targets (default: 60s)"
+  optional = true
+}
+
+argument "scrape_timeout" {
+  comment = "How long before a scrape times out (default: 10s)"
+  optional = true
+}
+
+argument "max_cache_size" {
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  optional = true
+}
+
+argument "clustering" {
+  // Docs: https://grafana.com/docs/agent/latest/flow/concepts/clustering/
+  comment = "Whether or not clustering should be enabled (default: false)"
+  optional = true
+}
+
+// cadvisor service discovery
+discovery.kubernetes "cadvisor" {
+  role = "node"
+}
+
+// cadvisor relabelings (pre-scrape)
+discovery.relabel "cadvisor" {
+  targets = discovery.kubernetes.cadvisor.targets
+
+  // drop all targets if enabled is false
+  rule {
+    target_label = "__enabled"
+    replacement = format("%s", coalesce(argument.enabled.value, "true"))
+  }
+  rule {
+    source_labels = ["__enabled"]
+    regex = "false"
+    action = "drop"
+  }
+
+  // set the address to use the kubernetes service dns name
+  rule {
+    target_label = "__address__"
+    replacement  = "kubernetes.default.svc.cluster.local:443"
+  }
+
+  // set the metrics path to use the proxy path to the nodes cadvisor metrics endpoint
+  rule {
+    source_labels = ["__meta_kubernetes_node_name"]
+    regex         = "(.+)"
+    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
+}
+
+// cadvisor scrape job
+prometheus.scrape "cadvisor" {
+  job_name = coalesce(argument.job_label.value, "integrations/kubernetes/cadvisor")
+  forward_to = [prometheus.relabel.cadvisor.receiver]
+  targets = discovery.relabel.cadvisor.output
+  scheme = "https"
+  scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+  scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+  tls_config {
+    ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    insecure_skip_verify = false
+    server_name = "kubernetes"
+  }
+
+  clustering {
+    enabled = coalesce(argument.clustering.value, false)
+  }
+
+}
+
+// cadvisor metric relabelings (post-scrape)
+prometheus.relabel "cadvisor" {
+  forward_to = argument.forward_to.value
+  max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+  // keep only metrics that match the keep_metrics regex
+  rule {
+    source_labels = ["__name__"]
+    regex = coalesce(argument.keep_metrics.value, "(up|container_(cpu_(cfs_(periods|throttled_periods)_total|usage_seconds_total)|fs_(reads|writes)(_bytes)?_total|memory_(cache|rss|swap|working_set_bytes)|network_(receive|transmit)_(bytes|packets(_dropped)?_total))|machine_memory_bytes)")
+    action = "keep"
+  }
+
+  // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+  rule {
+    source_labels = ["__name__","container"]
+    separator = "@"
+    regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+    action = "drop"
+  }
+
+  // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+  rule {
+    source_labels = ["__name__","image"]
+    separator = "@"
+    regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+    action = "drop"
+  }
+
+  // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+  rule {
+    source_labels = ["__name__", "boot_id"]
+    separator = "@"
+    regex = "machine_memory_bytes@.*"
+    target_label = "boot_id"
+    replacement = "NA"
+  }
+  rule {
+    source_labels = ["__name__", "system_uuid"]
+    separator = "@"
+    regex = "machine_memory_bytes@.*"
+    target_label = "system_uuid"
+    replacement = "NA"
+  }
+
+  // Filter out non-physical devices/interfaces
+  rule {
+    source_labels = ["__name__", "device"]
+    separator = "@"
+    regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+    target_label = "__keepme"
+    replacement = "1"
+  }
+  rule {
+    source_labels = ["__name__", "__keepme"]
+    separator = "@"
+    regex = "container_fs_.*@"
+    action = "drop"
+  }
+  rule {
+    source_labels = ["__name__"]
+    regex = "container_fs_.*"
+    target_label = "__keepme"
+    replacement = ""
+  }
+  rule {
+    source_labels = ["__name__", "interface"]
+    separator = "@"
+    regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+    target_label = "__keepme"
+    replacement = "1"
+  }
+  rule {
+    source_labels = ["__name__", "__keepme"]
+    separator = "@"
+    regex = "container_network_.*@"
+    action = "drop"
+  }
+  rule {
+    source_labels = ["__name__"]
+    regex = "container_network_.*"
+    target_label = "__keepme"
+    replacement = ""
+  }
+}

--- a/modules/kubernetes/metrics/jobs/gitlab-exporter.river
+++ b/modules/kubernetes/metrics/jobs/gitlab-exporter.river
@@ -57,7 +57,7 @@ argument "scrape_timeout" {
 }
 
 argument "max_cache_size" {
-  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
   optional = true
 }
 

--- a/modules/kubernetes/metrics/jobs/gitlab-exporter.river
+++ b/modules/kubernetes/metrics/jobs/gitlab-exporter.river
@@ -1,0 +1,130 @@
+/*
+Module: job-gitlab-exporter
+Docs: https://github.com/mvisonneau/gitlab-ci-pipelines-exporter
+Description: Scrapes Git Lab Metrics, this is a separate scrape job, if you are also using annotation based scraping, you will want to explicitly
+             disable gitlab-exporter from being scraped by this module and annotations by setting the following annotation on the gitlab-exporter
+             metrics.agent.grafana.com/scrape: "false"
+
+Note: Every argument except for "forward_to" is optional, and does have a defined default value.  However, the values for these
+      arguments are not defined using the default = " ... " argument syntax, but rather using the coalesce(argument.value, " ... ").
+      This is because if the argument passed in from another consuming module is set to null, the default = " ... " syntax will
+      does not override the value passed in, where coalesce() will return the first non-null value.
+*/
+argument "forward_to" {
+  comment = "Must be a list(MetricsReceiver) where collected logs should be forwarded to"
+  optional = false
+}
+
+argument "enabled" {
+  comment = "Whether or not the gitlab-exporter job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment"
+  optional = true
+}
+
+argument "namespaces" {
+  comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+  optional = true
+}
+
+argument "selectors" {
+  // see: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=gitlab-ci-pipelines-exporter\"])"
+  optional = true
+}
+
+argument "port_name" {
+  comment = "The of the port to scrape metrics from"
+  optional = true
+}
+
+argument "job_label" {
+  comment = "The job label to add for all gitlab-exporter metrics (default: integrations/gitlab)"
+  optional = true
+}
+
+argument "keep_metrics" {
+  optional = true
+  default = "(up|(gitlab_ci_pipeline_job_(timestamp|status|duration_seconds|id|run_count|artifact_size_bytes)|gitlab_runner_jobs_total|gcpe_.*))"
+}
+
+argument "scrape_interval" {
+  comment = "How often to scrape metrics from the targets (default: 60s)"
+  optional = true
+}
+
+argument "scrape_timeout" {
+  comment = "How long before a scrape times out (default: 10s)"
+  optional = true
+}
+
+argument "max_cache_size" {
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  optional = true
+}
+
+argument "clustering" {
+  // Docs: https://grafana.com/docs/agent/latest/flow/concepts/clustering/
+  comment = "Whether or not clustering should be enabled (default: false)"
+  optional = true
+}
+
+// gitlab-exporter service discovery
+discovery.kubernetes "gitlab" {
+  role = "service"
+
+  selectors {
+    role = "service"
+    label = join(coalesce(argument.selectors.value, ["app.kubernetes.io/name=gitlab-ci-pipelines-exporter"]), ",")
+  }
+
+  namespaces {
+    names = coalesce(argument.namespaces.value, [])
+  }
+}
+
+// gitlab-exporter relabelings (pre-scrape)
+discovery.relabel "gitlab" {
+  targets = discovery.kubernetes.gitlab.targets
+
+  // drop all targets if enabled is false
+  rule {
+    target_label = "__enabled"
+    replacement = format("%s", coalesce(argument.enabled.value, "true"))
+  }
+  rule {
+    source_labels = ["__enabled"]
+    regex = "false"
+    action = "drop"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = coalesce(argument.port_name.value, "http")
+    action = "keep"
+  }
+}
+
+// gitlab-exporter scrape job
+prometheus.scrape "gitlab" {
+  job_name = coalesce(argument.job_label.value, "integrations/gitlab")
+  forward_to = [prometheus.relabel.gitlab.receiver]
+  targets = discovery.relabel.gitlab.output
+  scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+  scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+
+  clustering {
+    enabled = coalesce(argument.clustering.value, false)
+  }
+}
+
+// gitlab-exporter metric relabelings (post-scrape)
+prometheus.relabel "gitlab" {
+  forward_to = argument.forward_to.value
+  max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+  // keep only metrics that match the keep_metrics regex
+  rule {
+    source_labels = ["__name__"]
+    regex = coalesce(argument.keep_metrics.value, "(gitlab_ci_pipeline_job_(timestamp|status|duration_seconds|id|run_count|artifact_size_bytes)|gitlab_runner_jobs_total|gcpe_.*)")
+    action = "keep"
+  }
+}

--- a/modules/kubernetes/metrics/jobs/grafana.river
+++ b/modules/kubernetes/metrics/jobs/grafana.river
@@ -53,7 +53,7 @@ argument "scrape_timeout" {
 }
 
 argument "max_cache_size" {
-  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
   optional = true
 }
 

--- a/modules/kubernetes/metrics/jobs/grafana.river
+++ b/modules/kubernetes/metrics/jobs/grafana.river
@@ -1,0 +1,173 @@
+/*
+Module: job-grafana
+Description: Scrapes Grafana
+
+Note: Every argument except for "forward_to" is optional, and does have a defined default value.  However, the values for these
+      arguments are not defined using the default = " ... " argument syntax, but rather using the coalesce(argument.value, " ... ").
+      This is because if the argument passed in from another consuming module is set to null, the default = " ... " syntax will
+      does not override the value passed in, where coalesce() will return the first non-null value.
+*/
+argument "forward_to" {
+  comment = "Must be a list(MetricsReceiver) where collected logs should be forwarded to"
+}
+
+argument "enabled" {
+  comment = "Whether or not the grafana-job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment"
+  optional = true
+}
+
+argument "namespaces" {
+  comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+  optional = true
+}
+
+argument "selectors" {
+  // Docs: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=grafana\"])"
+  optional = true
+}
+
+argument "port_name" {
+  comment = "The of the port to scrape metrics from (default: http-metrics)"
+  optional = true
+}
+
+argument "job_label" {
+  comment = "The job label to add for all grafana-metric (default: integrations/grafana)"
+  optional = true
+}
+
+argument "keep_metrics" {
+  comment = "A regex of metrics to keep (default: see below)"
+  optional = true
+}
+
+argument "scrape_interval" {
+  comment = "How often to scrape metrics from the targets (default: 60s)"
+  optional = true
+}
+
+argument "scrape_timeout" {
+  comment = "How long before a scrape times out (default: 10s)"
+  optional = true
+}
+
+argument "max_cache_size" {
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  optional = true
+}
+
+argument "clustering" {
+  // Docs: https://grafana.com/docs/agent/latest/flow/concepts/clustering/
+  comment = "Whether or not clustering should be enabled (default: false)"
+  optional = true
+}
+
+// grafana service discovery for all of the pods in the grafana daemonset
+discovery.kubernetes "grafana" {
+  role = "pod"
+
+  selectors {
+    role = "pod"
+    label = join(coalesce(argument.selectors.value, ["app.kubernetes.io/name=grafana"]), ",")
+  }
+
+  namespaces {
+    names = coalesce(argument.namespaces.value, [])
+  }
+}
+
+// grafana relabelings (pre-scrape)
+discovery.relabel "grafana" {
+  targets = discovery.kubernetes.grafana.targets
+
+  // drop all targets if enabled is false
+  rule {
+    target_label = "__enabled"
+    replacement = format("%s", coalesce(argument.enabled.value, "true"))
+  }
+  rule {
+    source_labels = ["__enabled"]
+    regex = "false"
+    action = "drop"
+  }
+
+  // keep only the specified metrics port name, and pods that are Running and ready
+  rule {
+    source_labels = [
+      "__meta_kubernetes_pod_container_port_name",
+      "__meta_kubernetes_pod_phase",
+      "__meta_kubernetes_pod_ready",
+    ]
+    separator = "@"
+    regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true"
+    action = "keep"
+  }
+
+  // set the namespace label
+  rule {
+    source_labels = ["__meta_kubernetes_namespace"]
+    target_label  = "namespace"
+  }
+
+  // set the pod label
+  rule {
+    source_labels = ["__meta_kubernetes_pod_name"]
+    target_label  = "pod"
+  }
+
+  // set the container label
+  rule {
+    source_labels = ["__meta_kubernetes_pod_container_name"]
+    target_label  = "container"
+  }
+
+  // set a controller label
+  rule {
+    source_labels = [
+      "__meta_kubernetes_pod_controller_kind",
+      "__meta_kubernetes_pod_controller_name",
+    ]
+    separator = "/"
+    target_label  = "controller"
+  }
+
+  // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+      "__meta_kubernetes_pod_label_k8s_app",
+      "__meta_kubernetes_pod_label_app",
+    ]
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "app"
+  }
+}
+
+// grafana scrape job
+prometheus.scrape "grafana" {
+  job_name = coalesce(argument.job_label.value, "integrations/grafana")
+  forward_to = [prometheus.relabel.grafana.receiver]
+  targets = discovery.relabel.grafana.output
+  scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+  scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+
+  clustering {
+    enabled = coalesce(argument.clustering.value, false)
+  }
+}
+
+// grafana-metric relabelings (post-scrape)
+prometheus.relabel "grafana" {
+  forward_to = argument.forward_to.value
+  max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+  // keep only metrics that match the keep_metrics regex
+  rule {
+    source_labels = ["__name__"]
+    regex = coalesce(argument.keep_metrics.value, "(.+)")
+    action = "keep"
+  }
+}

--- a/modules/kubernetes/metrics/jobs/kube-apiserver.river
+++ b/modules/kubernetes/metrics/jobs/kube-apiserver.river
@@ -60,7 +60,7 @@ argument "scrape_timeout" {
 }
 
 argument "max_cache_size" {
-  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
   optional = true
 }
 

--- a/modules/kubernetes/metrics/jobs/kube-apiserver.river
+++ b/modules/kubernetes/metrics/jobs/kube-apiserver.river
@@ -1,0 +1,166 @@
+/*
+Module: job-kube-apiserver
+Description: Scrapes Kube API Server
+
+Note: Every argument except for "forward_to" is optional, and does have a defined default value.  However, the values for these
+      arguments are not defined using the default = " ... " argument syntax, but rather using the coalesce(argument.value, " ... ").
+      This is because if the argument passed in from another consuming module is set to null, the default = " ... " syntax will
+      does not override the value passed in, where coalesce() will return the first non-null value.
+*/
+argument "forward_to" {
+  comment = "Must be a list(MetricsReceiver) where collected logs should be forwarded to"
+  optional = false
+}
+
+argument "enabled" {
+  comment = "Whether or not the kube-apiserver job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment"
+  optional = true
+}
+
+argument "namespace" {
+  comment = "The namespaces to look for targets in (default: default)"
+  optional = true
+}
+
+argument "service" {
+  comment = "The label to use for the selector (default: kubernetes)"
+  optional = true
+}
+
+argument "port_name" {
+  comment = "The value of the label for the selector (default: https)"
+  optional = true
+}
+
+argument "job_label" {
+  comment = "The job label to add for all kube-apiserver metrics (default: integrations/kubernetes/kube-apiserver)"
+  optional = true
+}
+
+// drop metrics and les from kube-prometheus
+// https://github.com/prometheus-operator/kube-prometheus/blob/main/manifests/kubernetesControlPlane-serviceMonitorApiserver.yaml
+argument "drop_metrics" {
+  comment = "Regex of metrics to drop (default: see below)"
+  optional = true
+}
+
+argument "drop_les" {
+  comment = "Regex of metric les label values to drop (default: see below)"
+  optional = true
+}
+
+argument "scrape_interval" {
+  comment = "How often to scrape metrics from the targets (default: 60s)"
+  optional = true
+}
+
+argument "scrape_timeout" {
+  comment = "How long before a scrape times out (default: 10s)"
+  optional = true
+}
+
+argument "max_cache_size" {
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  optional = true
+}
+
+argument "clustering" {
+  // Docs: https://grafana.com/docs/agent/latest/flow/concepts/clustering/
+  comment = "Whether or not clustering should be enabled (default: false)"
+  optional = true
+}
+
+// kube-apiserver service discovery
+discovery.kubernetes "kube_apiserver" {
+  role = "service"
+
+  selectors {
+    role = "service"
+    field = "metadata.name=" + coalesce(argument.service.value, "kubernetes")
+  }
+
+  namespaces {
+    names = [coalesce(argument.namespace.value, "default")]
+  }
+}
+
+// kube-apiserver relabelings (pre-scrape)
+discovery.relabel "kube_apiserver" {
+  targets = discovery.kubernetes.kube_apiserver.targets
+
+  // drop all targets if enabled is false
+  rule {
+    target_label = "__enabled"
+    replacement = format("%s", coalesce(argument.enabled.value, "true"))
+  }
+  rule {
+    source_labels = ["__enabled"]
+    regex = "false"
+    action = "drop"
+  }
+
+  // only keep targets with a matching port name
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = coalesce(argument.port_name.value, "https")
+    action = "keep"
+  }
+
+  // set the namespace
+  rule {
+    action = "replace"
+    source_labels = ["__meta_kubernetes_namespace"]
+    target_label = "namespace"
+  }
+
+  // set the service_name
+  rule {
+    action = "replace"
+    source_labels = ["__meta_kubernetes_service_name"]
+    target_label = "service"
+  }
+}
+
+// kube-apiserver scrape job
+prometheus.scrape "kube_apiserver" {
+  job_name = coalesce(argument.job_label.value, "integrations/kubernetes/kube-apiserver")
+  forward_to = [prometheus.relabel.kube_apiserver.receiver]
+  targets = discovery.relabel.kube_apiserver.output
+  scheme = "https"
+  scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+  scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+  tls_config {
+    ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    insecure_skip_verify = false
+    server_name = "kubernetes"
+  }
+
+  clustering {
+    enabled = coalesce(argument.clustering.value, false)
+  }
+}
+
+// kube-apiserver metric relabelings (post-scrape)
+prometheus.relabel "kube_apiserver" {
+  forward_to = argument.forward_to.value
+  max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+  // drop metrics that match the drop_metrics regex
+  rule {
+    source_labels = ["__name__"]
+    regex = coalesce(argument.drop_metrics.value, "(kubelet_(pod_(worker|start)_latency_microseconds|cgroup_manager_latency_microseconds|pleg_relist_(latency|interval)_microseconds|runtime_operations(_latency_microseconds|_errors)?|eviction_stats_age_microseconds|device_plugin_(registration_count|alloc_latency_microseconds)|network_plugin_operations_latency_microseconds)|scheduler_(e2e_scheduling_latency_microseconds|scheduling_algorithm_(predicate|priority|preemption)_evaluation|scheduling_algorithm_latency_microseconds|binding_latency_microseconds|scheduling_latency_seconds)|apiserver_(request_(count|latencies(_summary)?)|dropped_requests|storage_(data_key_generation|transformation_(failures_total|latencies_microseconds))|proxy_tunnel_sync_latency_secs|longrunning_gauge|registered_watchers)|kubelet_docker_(operations(_latency_microseconds|_errors|_timeout)?)|reflector_(items_per_(list|watch)|list_duration_seconds|lists_total|short_watches_total|watch_duration_seconds|watches_total)|etcd_(helper_(cache_(hit|miss)_count|cache_entry_count|object_counts)|request_(cache_(get|add)_latencies_summary|latencies_summary)|debugging.*|disk.*|server.*)|transformation_(latencies_microseconds|failures_total)|(admission_quota_controller|APIServiceOpenAPIAggregationControllerQueue1|APIServiceRegistrationController|autoregister|AvailableConditionController|crd_(autoregistration_controller|Establishing|finalizer|naming_condition_controller|openapi_controller)|DiscoveryController|non_structural_schema_condition_controller|kubeproxy_sync_proxy_rules|rest_client_request_latency|storage_operation_(errors_total|status_count))(_.*)|apiserver_admission_(controller_admission|step_admission)_latencies_seconds_.*)")
+    action = "drop"
+  }
+
+  // drop metrics whose name and le label match the drop_les regex
+  rule {
+    source_labels = [
+      "__name__",
+      "le",
+    ]
+    regex = coalesce(argument.drop_les.value, "apiserver_request_duration_seconds_bucket;(0.15|0.25|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2.5|3|3.5|4.5|6|7|8|9|15|25|30|50)")
+    action = "drop"
+  }
+}

--- a/modules/kubernetes/metrics/jobs/kube-probes.river
+++ b/modules/kubernetes/metrics/jobs/kube-probes.river
@@ -1,0 +1,120 @@
+/*
+Module: job-kube-probes
+Description: Scrapes Kube Probes Metrics
+
+Note: Every argument except for "forward_to" is optional, and does have a defined default value.  However, the values for these
+      arguments are not defined using the default = " ... " argument syntax, but rather using the coalesce(argument.value, " ... ").
+      This is because if the argument passed in from another consuming module is set to null, the default = " ... " syntax will
+      does not override the value passed in, where coalesce() will return the first non-null value.
+*/
+argument "forward_to" {
+  comment = "Must be a list(MetricsReceiver) where collected logs should be forwarded to"
+  optional = false
+}
+
+argument "enabled" {
+  comment = "Whether or not the kube-probes job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment"
+  optional = true
+}
+
+argument "job_label" {
+  comment = "The job label to add for all kube metrics (default: integrations/kubernetes/kube-probes)"
+  optional = true
+}
+
+argument "keep_metrics" {
+  comment = "A regex of metrics to keep"
+  optional = true
+}
+
+argument "scrape_interval" {
+  comment = "How often to scrape metrics from the targets (default: 60s)"
+  optional = true
+}
+
+argument "scrape_timeout" {
+  comment = "How long before a scrape times out (default: 10s)"
+  optional = true
+}
+
+argument "max_cache_size" {
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  optional = true
+}
+
+argument "clustering" {
+  // Docs: https://grafana.com/docs/agent/latest/flow/concepts/clustering/
+  comment = "Whether or not clustering should be enabled (default: false)"
+  optional = true
+}
+
+// kube probes service discovery
+discovery.kubernetes "kube_probes" {
+  role = "node"
+}
+
+// kube probes relabelings (pre-scrape)
+discovery.relabel "kube_probes" {
+  targets = discovery.kubernetes.kube_probes.targets
+
+  // drop all targets if enabled is false
+  rule {
+    target_label = "__enabled"
+    replacement = format("%s", coalesce(argument.enabled.value, "true"))
+  }
+  rule {
+    source_labels = ["__enabled"]
+    regex = "false"
+    action = "drop"
+  }
+
+  // set the address to use the kubernetes service dns name
+  rule {
+    target_label = "__address__"
+    replacement  = "kubernetes.default.svc.cluster.local:443"
+  }
+
+  // set the metrics path to use the proxy path to the nodes probes metrics endpoint
+  rule {
+    action = "replace"
+    source_labels = ["__meta_kubernetes_node_name"]
+    regex = "(.+)"
+    replacement = "/api/v1/nodes/${1}/proxy/metrics/probes"
+    target_label = "__metrics_path__"
+  }
+}
+
+// kube probes scrape job
+prometheus.scrape "kube_probes" {
+  job_name = coalesce(argument.job_label.value, "integrations/kubernetes/kube-probes")
+  forward_to = [prometheus.relabel.kube_probes.receiver]
+  targets = discovery.relabel.kube_probes.output
+  scheme = "https"
+  scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+  scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+  tls_config {
+    ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    insecure_skip_verify = false
+    server_name = "kubernetes"
+  }
+
+  clustering {
+    enabled = coalesce(argument.clustering.value, false)
+  }
+
+}
+
+// kube probes metric relabelings (post-scrape)
+prometheus.relabel "kube_probes" {
+  forward_to = argument.forward_to.value
+  max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+  // keep only metrics that match the keep_metrics regex
+  rule {
+    source_labels = ["__name__"]
+    regex = coalesce(argument.keep_metrics.value, "(.+)")
+    action = "keep"
+  }
+}

--- a/modules/kubernetes/metrics/jobs/kube-probes.river
+++ b/modules/kubernetes/metrics/jobs/kube-probes.river
@@ -38,7 +38,7 @@ argument "scrape_timeout" {
 }
 
 argument "max_cache_size" {
-  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
   optional = true
 }
 

--- a/modules/kubernetes/metrics/jobs/kube-proxy.river
+++ b/modules/kubernetes/metrics/jobs/kube-proxy.river
@@ -54,7 +54,7 @@ argument "scrape_timeout" {
 }
 
 argument "max_cache_size" {
-  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
   optional = true
 }
 

--- a/modules/kubernetes/metrics/jobs/kube-proxy.river
+++ b/modules/kubernetes/metrics/jobs/kube-proxy.river
@@ -1,0 +1,127 @@
+/*
+Module: job-kube-proxy
+Description: Kube Proxy
+
+Note: Every argument except for "forward_to" is optional, and does have a defined default value.  However, the values for these
+      arguments are not defined using the default = " ... " argument syntax, but rather using the coalesce(argument.value, " ... ").
+      This is because if the argument passed in from another consuming module is set to null, the default = " ... " syntax will
+      does not override the value passed in, where coalesce() will return the first non-null value.
+*/
+argument "forward_to" {
+  comment = "Must be a list(MetricsReceiver) where collected logs should be forwarded to"
+  optional = false
+}
+
+argument "enabled" {
+  comment = "Whether or not the kube-proxy job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment"
+  optional = true
+}
+
+argument "namespace" {
+  comment = "The namespace to look for targets in (default: kube-system)"
+  optional = true
+}
+
+argument "selectors" {
+  // see: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  comment = "The label selectors to use to find matching targets (default: [\"component=kube-proxy\"])"
+  optional = true
+}
+
+argument "port" {
+  comment = "The port to scrape kube-proxy metrics on (default: 10249))"
+  optional = true
+}
+
+argument "job_label" {
+  comment = "The job label to add for all kube-proxy metrics (default: integrations/kubernetes/kube-proxy)"
+  optional = true
+}
+
+argument "keep_metrics" {
+  comment = "A regex of metrics to keep (default: see below)"
+  optional = true
+}
+
+argument "scrape_interval" {
+  comment = "How often to scrape metrics from the targets (default: 60s)"
+  optional = true
+}
+
+argument "scrape_timeout" {
+  comment = "How long before a scrape times out (default: 10s)"
+  optional = true
+}
+
+argument "max_cache_size" {
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  optional = true
+}
+
+argument "clustering" {
+  // Docs: https://grafana.com/docs/agent/latest/flow/concepts/clustering/
+  comment = "Whether or not clustering should be enabled (default: false)"
+  optional = true
+}
+
+// kube-proxy service discovery for all of the pods in the kube_proxy daemonset
+discovery.kubernetes "kube_proxy" {
+  role = "pod"
+
+  selectors {
+    role = "pod"
+    label = join(coalesce(argument.selectors.value, ["component=kube-proxy"]), ",")
+  }
+
+  namespaces {
+    names = [coalesce(argument.namespace.value, "kube-system")]
+  }
+}
+
+// kube_proxy relabelings (pre-scrape)
+discovery.relabel "kube_proxy" {
+  targets = discovery.kubernetes.kube_proxy.targets
+
+  // drop all targets if enabled is false
+  rule {
+    target_label = "__enabled"
+    replacement = format("%s", coalesce(argument.enabled.value, "true"))
+  }
+  rule {
+    source_labels = ["__enabled"]
+    regex = "false"
+    action = "drop"
+  }
+
+  rule {
+    source_labels = ["__address__"]
+    replacement = "$1:" + format("%s", coalesce(argument.port.value, "10249"))
+    target_label = "__address__"
+  }
+}
+
+// kube_proxy scrape job
+prometheus.scrape "kube_proxy" {
+  job_name = coalesce(argument.job_label.value, "integrations/kubernetes/kube-proxy")
+  forward_to = [prometheus.relabel.kube_proxy.receiver]
+  targets = discovery.relabel.kube_proxy.output
+  scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+  scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+
+  clustering {
+    enabled = coalesce(argument.clustering.value, false)
+  }
+}
+
+// kube-proxy metric relabelings (post-scrape)
+prometheus.relabel "kube_proxy" {
+  forward_to = argument.forward_to.value
+  max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+  // keep only metrics that match the keep_metrics regex
+  rule {
+    source_labels = ["__name__"]
+    regex = coalesce(argument.keep_metrics.value, "(.+)")
+    action = "keep"
+  }
+}

--- a/modules/kubernetes/metrics/jobs/kube-resource.river
+++ b/modules/kubernetes/metrics/jobs/kube-resource.river
@@ -38,7 +38,7 @@ argument "scrape_timeout" {
 }
 
 argument "max_cache_size" {
-  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
   optional = true
 }
 

--- a/modules/kubernetes/metrics/jobs/kube-resource.river
+++ b/modules/kubernetes/metrics/jobs/kube-resource.river
@@ -1,0 +1,120 @@
+/*
+Module: job-kube-resources
+Description: Scrapes Kube Resources Metrics
+
+Note: Every argument except for "forward_to" is optional, and does have a defined default value.  However, the values for these
+      arguments are not defined using the default = " ... " argument syntax, but rather using the coalesce(argument.value, " ... ").
+      This is because if the argument passed in from another consuming module is set to null, the default = " ... " syntax will
+      does not override the value passed in, where coalesce() will return the first non-null value.
+*/
+argument "forward_to" {
+  // comment = "Must be a list(MetricssReceiver) where collected logs should be forwarded to"
+  optional = false
+}
+
+argument "enabled" {
+  comment = "Whether or not the kube-resource job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment"
+  optional = true
+}
+
+argument "job_label" {
+  comment = "The job label to add for all kube metrics (default: integrations/kubernetes/kube-resources)"
+  optional = true
+}
+
+argument "keep_metrics" {
+  comment = "A regex of metrics to keep (default: see below)"
+  optional = true
+}
+
+argument "scrape_interval" {
+  comment = "How often to scrape metrics from the targets (default: 60s)"
+  optional = true
+}
+
+argument "scrape_timeout" {
+  comment = "How long before a scrape times out (default: 10s)"
+  optional = true
+}
+
+argument "max_cache_size" {
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  optional = true
+}
+
+argument "clustering" {
+  // Docs: https://grafana.com/docs/agent/latest/flow/concepts/clustering/
+  comment = "Whether or not clustering should be enabled (default: false)"
+  optional = true
+}
+
+// kube resource service discovery
+discovery.kubernetes "kube_resource" {
+  role = "node"
+}
+
+// kube resource relabelings (pre-scrape)
+discovery.relabel "kube_resource" {
+  targets = discovery.kubernetes.kube_resource.targets
+
+  // drop all targets if enabled is false
+  rule {
+    target_label = "__enabled"
+    replacement = format("%s", coalesce(argument.enabled.value, "true"))
+  }
+  rule {
+    source_labels = ["__enabled"]
+    regex = "false"
+    action = "drop"
+  }
+
+  // set the address to use the kubernetes service dns name
+  rule {
+    target_label = "__address__"
+    replacement  = "kubernetes.default.svc.cluster.local:443"
+  }
+
+  // set the metrics path to use the proxy path to the nodes resource metrics endpoint
+  rule {
+    action = "replace"
+    source_labels = ["__meta_kubernetes_node_name"]
+    regex = "(.+)"
+    replacement = "/api/v1/nodes/${1}/proxy/metrics/resource"
+    target_label = "__metrics_path__"
+  }
+}
+
+// kube resource scrape job
+prometheus.scrape "kube_resource" {
+  job_name = coalesce(argument.job_label.value, "integrations/kubernetes/kube-resources")
+  forward_to = [prometheus.relabel.kube_resource.receiver]
+  targets = discovery.relabel.kube_resource.output
+  scheme = "https"
+  scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+  scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+  tls_config {
+    ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    insecure_skip_verify = false
+    server_name = "kubernetes"
+  }
+
+  clustering {
+    enabled = coalesce(argument.clustering.value, false)
+  }
+
+}
+
+// kube resource metric relabelings (post-scrape)
+prometheus.relabel "kube_resource" {
+  forward_to = argument.forward_to.value
+  max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+  // keep only metrics that match the keep_metrics regex
+  rule {
+    source_labels = ["__name__"]
+    regex = coalesce(argument.keep_metrics.value, "(.+)")
+    action = "keep"
+  }
+}

--- a/modules/kubernetes/metrics/jobs/kube-state-metrics.river
+++ b/modules/kubernetes/metrics/jobs/kube-state-metrics.river
@@ -1,0 +1,130 @@
+/*
+Module: job-kube-state-metrics
+Description: Scrapes Kube-State-Metrics, this is a separate scrape job, if you are also using annotation based scraping, you will want to explicitly
+             disable kube-state-metrics from being scraped by this module and annotations by setting the following annotation on the kube-state-metrics
+             metrics.agent.grafana.com/scrape: "false"
+
+Note: Every argument except for "forward_to" is optional, and does have a defined default value.  However, the values for these
+      arguments are not defined using the default = " ... " argument syntax, but rather using the coalesce(argument.value, " ... ").
+      This is because if the argument passed in from another consuming module is set to null, the default = " ... " syntax will
+      does not override the value passed in, where coalesce() will return the first non-null value.
+*/
+argument "forward_to" {
+  comment = "Must be a list(MetricsReceiver) where collected logs should be forwarded to"
+  optional = false
+}
+
+argument "enabled" {
+  comment = "Whether or not the kube-state-metrics job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment"
+  optional = true
+}
+
+argument "namespaces" {
+  comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+  optional = true
+}
+
+argument "selectors" {
+  // see: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=kube-state-metrics\"])"
+  optional = true
+}
+
+argument "port_name" {
+  comment = "The of the port to scrape metrics from"
+  optional = true
+  default = "http"
+}
+
+argument "job_label" {
+  comment = "The job label to add for all kube-state-metrics metrics (default: integrations/kubernetes/kube-state-metrics)"
+  optional = true
+}
+
+argument "keep_metrics" {
+  comment = "A regex of metrics to keep (default: see below)"
+  optional = true
+}
+
+argument "scrape_interval" {
+  comment = "How often to scrape metrics from the targets (default: 60s)"
+  optional = true
+}
+
+argument "scrape_timeout" {
+  comment = "How long before a scrape times out (default: 10s)"
+  optional = true
+}
+
+argument "max_cache_size" {
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  optional = true
+}
+
+argument "clustering" {
+  // Docs: https://grafana.com/docs/agent/latest/flow/concepts/clustering/
+  comment = "Whether or not clustering should be enabled (default: false)"
+  optional = true
+}
+
+// kube-state-metrics service discovery
+discovery.kubernetes "kube_state_metrics" {
+  role = "service"
+
+  selectors {
+    role = "service"
+    label = join(coalesce(argument.selectors.value, ["app.kubernetes.io/name=kube-state-metrics"]), ",")
+  }
+
+  namespaces {
+    names = coalesce(argument.namespaces.value, [])
+  }
+}
+
+// kube-state-metrics relabelings (pre-scrape)
+discovery.relabel "kube_state_metrics" {
+  targets = discovery.kubernetes.kube_state_metrics.targets
+
+  // drop all targets if enabled is false
+  rule {
+    target_label = "__enabled"
+    replacement = format("%s", coalesce(argument.enabled.value, "true"))
+  }
+  rule {
+    source_labels = ["__enabled"]
+    regex = "false"
+    action = "drop"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = argument.port_name.value
+    action = "keep"
+  }
+}
+
+// kube-state-metrics scrape job
+prometheus.scrape "kube_state_metrics" {
+  job_name = coalesce(argument.job_label.value, "integrations/kubernetes/kube-state-metrics")
+  forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  targets = discovery.relabel.kube_state_metrics.output
+  scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+  scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+
+  clustering {
+    enabled = coalesce(argument.clustering.value, false)
+  }
+}
+
+// kube-state-metrics metric relabelings (post-scrape)
+prometheus.relabel "kube_state_metrics" {
+  forward_to = argument.forward_to.value
+  max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+  // keep only metrics that match the keep_metrics regex
+  rule {
+    source_labels = ["__name__"]
+    regex = coalesce(argument.keep_metrics.value, "(up|kube_(daemonset.*|deployment_(metadata_generation|spec_replicas|status_(observed_generation|replicas_(available|updated)))|horizontalpodautoscaler_(spec_(max|min)_replicas|status_(current|desired)_replicas)|job.*|namespace_status_phase|node.*|persistentvolumeclaim_resource_requests_storage_bytes|pod_(container_(info|resource_(limits|requests)|status_(last_terminated_reason|restarts_total|waiting_reason))|info|owner|start_time|status_(phase|reason))|replicaset.*|resourcequota|statefulset.*))")
+    action = "keep"
+  }
+}

--- a/modules/kubernetes/metrics/jobs/kube-state-metrics.river
+++ b/modules/kubernetes/metrics/jobs/kube-state-metrics.river
@@ -57,7 +57,7 @@ argument "scrape_timeout" {
 }
 
 argument "max_cache_size" {
-  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
   optional = true
 }
 

--- a/modules/kubernetes/metrics/jobs/kubelet.river
+++ b/modules/kubernetes/metrics/jobs/kubelet.river
@@ -1,0 +1,119 @@
+/*
+Module: job-kubelet
+Description: Scrapes Kublet Metrics
+
+Note: Every argument except for "forward_to" is optional, and does have a defined default value.  However, the values for these
+      arguments are not defined using the default = " ... " argument syntax, but rather using the coalesce(argument.value, " ... ").
+      This is because if the argument passed in from another consuming module is set to null, the default = " ... " syntax will
+      does not override the value passed in, where coalesce() will return the first non-null value.
+*/
+argument "forward_to" {
+  comment = "Must be a list(MetricsReceiver) where collected logs should be forwarded to"
+  optional = false
+}
+
+argument "enabled" {
+  comment = "Whether or not the kubelet job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment"
+  optional = true
+}
+
+argument "job_label" {
+  comment = "The job label to add for all kubelet metrics (default: integrations/kubernetes/kubelet)"
+  optional = true
+}
+
+argument "keep_metrics" {
+  comment = "A regex of metrics to keep"
+  optional = true
+}
+
+argument "scrape_interval" {
+  comment = "How often to scrape metrics from the targets (default: 60s)"
+  optional = true
+}
+
+argument "scrape_timeout" {
+  comment = "How long before a scrape times out (default: 10s)"
+  optional = true
+}
+
+argument "max_cache_size" {
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  optional = true
+}
+
+argument "clustering" {
+  // Docs: https://grafana.com/docs/agent/latest/flow/concepts/clustering/
+  comment = "Whether or not clustering should be enabled (default: false)"
+  optional = true
+}
+
+// kubelet service discovery
+discovery.kubernetes "kubelet" {
+  role = "node"
+}
+
+// kubelet relabelings (pre-scrape)
+discovery.relabel "kubelet" {
+  targets = discovery.kubernetes.kubelet.targets
+
+  // drop all targets if enabled is false
+  rule {
+    target_label = "__enabled"
+    replacement = format("%s", coalesce(argument.enabled.value, "true"))
+  }
+  rule {
+    source_labels = ["__enabled"]
+    regex = "false"
+    action = "drop"
+  }
+
+  // set the address to use the kubernetes service dns name
+  rule {
+    target_label = "__address__"
+    replacement  = "kubernetes.default.svc.cluster.local:443"
+  }
+
+  // set the metrics path to use the proxy path to the nodes kubelet metrics endpoint
+  rule {
+    source_labels = ["__meta_kubernetes_node_name"]
+    regex         = "(.+)"
+    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
+    target_label  = "__metrics_path__"
+  }
+}
+
+// kubelet scrape job
+prometheus.scrape "kubelet" {
+  job_name = coalesce(argument.job_label.value, "integrations/kubernetes/kubelet")
+  forward_to = [prometheus.relabel.kubelet.receiver]
+  targets = discovery.relabel.kubelet.output
+  scheme = "https"
+  scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+  scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+  tls_config {
+    ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    insecure_skip_verify = false
+    server_name = "kubernetes"
+  }
+
+  clustering {
+    enabled = coalesce(argument.clustering.value, false)
+  }
+
+}
+
+// kubelet metric relabelings (post-scrape)
+prometheus.relabel "kubelet" {
+  forward_to = argument.forward_to.value
+  max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+  // keep only metrics that match the keep_metrics regex
+  rule {
+    source_labels = ["__name__"]
+    regex = coalesce(argument.keep_metrics.value, "(up|container_cpu_usage_seconds_total|kubelet_(certificate_manager_(client|server)_ttl_seconds|cgroup_manager_duration_seconds_(bucket|count)|node_(config_error|name)|pleg_relist_duration_seconds_(bucket|count)|pleg_relist_interval_seconds_bucket|pod_(start|worker)_duration_seconds_(bucket|count)|running_(container|pod)_(count|s)|runtime_operations_(errors_)?total|server_expiration_renew_errors|volume_stats_(available|capacity)_bytes|volume_stats_inodes(_used)?)|kubernetes_build_info|namespace_workload_pod|rest_client_requests_total|storage_operation_(duration_seconds_count|errors_total)|volume_manager_total_volumes)")
+    action = "keep"
+  }
+}

--- a/modules/kubernetes/metrics/jobs/kubelet.river
+++ b/modules/kubernetes/metrics/jobs/kubelet.river
@@ -38,7 +38,7 @@ argument "scrape_timeout" {
 }
 
 argument "max_cache_size" {
-  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
   optional = true
 }
 

--- a/modules/kubernetes/metrics/jobs/loki.river
+++ b/modules/kubernetes/metrics/jobs/loki.river
@@ -53,7 +53,7 @@ argument "scrape_timeout" {
 }
 
 argument "max_cache_size" {
-  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
   optional = true
 }
 

--- a/modules/kubernetes/metrics/jobs/loki.river
+++ b/modules/kubernetes/metrics/jobs/loki.river
@@ -1,0 +1,189 @@
+/*
+Module: job-loki
+Description: Scrapes loki
+
+Note: Every argument except for "forward_to" is optional, and does have a defined default value.  However, the values for these
+      arguments are not defined using the default = " ... " argument syntax, but rather using the coalesce(argument.value, " ... ").
+      This is because if the argument passed in from another consuming module is set to null, the default = " ... " syntax will
+      does not override the value passed in, where coalesce() will return the first non-null value.
+*/
+argument "forward_to" {
+  comment = "Must be a list(MetricsReceiver) where collected logs should be forwarded to"
+}
+
+argument "enabled" {
+  comment = "Whether or not the loki-job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment"
+  optional = true
+}
+
+argument "namespaces" {
+  comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+  optional = true
+}
+
+argument "selectors" {
+  // Docs: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=loki\",\"app.kubernetes.io/name=enterprise-logs\"])"
+  optional = true
+}
+
+argument "port_name" {
+  comment = "The of the port to scrape metrics from (default: http-metrics)"
+  optional = true
+}
+
+argument "job_label" {
+  comment = "The job label to add for all loki-metric (default: integrations/loki)"
+  optional = true
+}
+
+argument "keep_metrics" {
+  comment = "A regex of metrics to keep (default: see below)"
+  optional = true
+}
+
+argument "scrape_interval" {
+  comment = "How often to scrape metrics from the targets (default: 60s)"
+  optional = true
+}
+
+argument "scrape_timeout" {
+  comment = "How long before a scrape times out (default: 10s)"
+  optional = true
+}
+
+argument "max_cache_size" {
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  optional = true
+}
+
+argument "clustering" {
+  // Docs: https://loki.com/docs/agent/latest/flow/concepts/clustering/
+  comment = "Whether or not clustering should be enabled (default: false)"
+  optional = true
+}
+
+// loki service discovery for all of the pods in the loki daemonset
+discovery.kubernetes "loki" {
+  role = "pod"
+
+  selectors {
+    role = "pod"
+    label = join(coalesce(argument.selectors.value, [
+      "app.kubernetes.io/name=loki",
+      "app.kubernetes.io/name=enterprise-logs",
+    ]), ",")
+  }
+
+  namespaces {
+    names = coalesce(argument.namespaces.value, [])
+  }
+}
+
+// loki relabelings (pre-scrape)
+discovery.relabel "loki" {
+  targets = discovery.kubernetes.loki.targets
+
+  // drop all targets if enabled is false
+  rule {
+    target_label = "__enabled"
+    replacement = format("%s", coalesce(argument.enabled.value, "true"))
+  }
+  rule {
+    source_labels = ["__enabled"]
+    regex = "false"
+    action = "drop"
+  }
+
+  // keep only the specified metrics port name, and pods that are Running and ready
+  rule {
+    source_labels = [
+      "__meta_kubernetes_pod_container_port_name",
+      "__meta_kubernetes_pod_phase",
+      "__meta_kubernetes_pod_ready",
+    ]
+    separator = "@"
+    regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true"
+    action = "keep"
+  }
+
+  // set the namespace label
+  rule {
+    source_labels = ["__meta_kubernetes_namespace"]
+    target_label  = "namespace"
+  }
+
+  // set the pod label
+  rule {
+    source_labels = ["__meta_kubernetes_pod_name"]
+    target_label  = "pod"
+  }
+
+  // set the container label
+  rule {
+    source_labels = ["__meta_kubernetes_pod_container_name"]
+    target_label  = "container"
+  }
+
+  // set a controller label
+  rule {
+    source_labels = [
+      "__meta_kubernetes_pod_controller_kind",
+      "__meta_kubernetes_pod_controller_name",
+    ]
+    separator = "/"
+    target_label  = "controller"
+  }
+
+  // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+      "__meta_kubernetes_pod_label_k8s_app",
+      "__meta_kubernetes_pod_label_app",
+    ]
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "app"
+  }
+
+  // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+      "__meta_kubernetes_pod_label_k8s_component",
+      "__meta_kubernetes_pod_label_component",
+    ]
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "app"
+  }
+}
+
+// loki scrape job
+prometheus.scrape "loki" {
+  job_name = coalesce(argument.job_label.value, "integrations/loki")
+  forward_to = [prometheus.relabel.loki.receiver]
+  targets = discovery.relabel.loki.output
+  scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+  scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+
+  clustering {
+    enabled = coalesce(argument.clustering.value, false)
+  }
+}
+
+// loki-metric relabelings (post-scrape)
+prometheus.relabel "loki" {
+  forward_to = argument.forward_to.value
+  max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+  // keep only metrics that match the keep_metrics regex
+  rule {
+    source_labels = ["__name__"]
+    regex = coalesce(argument.keep_metrics.value, "(.+)")
+    action = "keep"
+  }
+}

--- a/modules/kubernetes/metrics/jobs/memcached.river
+++ b/modules/kubernetes/metrics/jobs/memcached.river
@@ -53,7 +53,7 @@ argument "scrape_timeout" {
 }
 
 argument "max_cache_size" {
-  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
   optional = true
 }
 

--- a/modules/kubernetes/metrics/jobs/memcached.river
+++ b/modules/kubernetes/metrics/jobs/memcached.river
@@ -1,0 +1,175 @@
+/*
+Module: job-memcached
+Description: Scrapes grafana memcached
+
+Note: Every argument except for "forward_to" is optional, and does have a defined default value.  However, the values for these
+      arguments are not defined using the default = " ... " argument syntax, but rather using the coalesce(argument.value, " ... ").
+      This is because if the argument passed in from another consuming module is set to null, the default = " ... " syntax will
+      does not override the value passed in, where coalesce() will return the first non-null value.
+*/
+argument "forward_to" {
+  comment = "Must be a list(MetricsReceiver) where collected logs should be forwarded to"
+}
+
+argument "enabled" {
+  comment = "Whether or not the memcached job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment"
+  optional = true
+}
+
+argument "namespaces" {
+  comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+  optional = true
+}
+
+argument "selectors" {
+  // Docs: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=memcached\"])"
+  optional = true
+}
+
+argument "port_name" {
+  comment = "The of the port to scrape metrics from (default: metrics)"
+  optional = true
+}
+
+argument "job_label" {
+  comment = "The job label to add for all memcached metric (default: integrations/memcached)"
+  optional = true
+}
+
+argument "keep_metrics" {
+  comment = "A regex of metrics to keep (default: see below)"
+  optional = true
+}
+
+argument "scrape_interval" {
+  comment = "How often to scrape metrics from the targets (default: 60s)"
+  optional = true
+}
+
+argument "scrape_timeout" {
+  comment = "How long before a scrape times out (default: 10s)"
+  optional = true
+}
+
+argument "max_cache_size" {
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  optional = true
+}
+
+argument "clustering" {
+  // Docs: https://grafana.com/docs/memcached/latest/flow/concepts/clustering/
+  comment = "Whether or not clustering should be enabled (default: false)"
+  optional = true
+}
+
+// grafana memcached service discovery for all of the pods in the grafana memcached daemonset
+discovery.kubernetes "memcached" {
+  role = "pod"
+
+  selectors {
+    role = "pod"
+    label = join(coalesce(argument.selectors.value, ["app.kubernetes.io/name=memcached"]), ",")
+  }
+
+  namespaces {
+    names = coalesce(argument.namespaces.value, [])
+  }
+}
+
+// grafana memcached relabelings (pre-scrape)
+discovery.relabel "memcached" {
+  targets = discovery.kubernetes.memcached.targets
+
+  // drop all targets if enabled is false
+  rule {
+    target_label = "__enabled"
+    replacement = format("%s", coalesce(argument.enabled.value, "true"))
+  }
+  rule {
+    source_labels = ["__enabled"]
+    regex = "false"
+    action = "drop"
+  }
+
+  // keep only the specified metrics port name, and pods that are Running and ready
+  rule {
+    source_labels = [
+      "__meta_kubernetes_pod_container_port_name",
+      "__meta_kubernetes_pod_phase",
+      "__meta_kubernetes_pod_ready",
+    ]
+    separator = "@"
+    regex = coalesce(argument.port_name.value, "metrics") + "@Running@true"
+    action = "keep"
+  }
+
+  // set the namespace label
+  rule {
+    source_labels = ["__meta_kubernetes_namespace"]
+    target_label  = "namespace"
+  }
+
+  // set the pod label
+  rule {
+    source_labels = ["__meta_kubernetes_pod_name"]
+    target_label  = "pod"
+  }
+
+  // set the container label
+  rule {
+    source_labels = ["__meta_kubernetes_pod_container_name"]
+    target_label  = "container"
+  }
+
+  // set a controller label
+  rule {
+    source_labels = [
+      "__meta_kubernetes_pod_controller_kind",
+      "__meta_kubernetes_pod_controller_name",
+    ]
+    separator = "/"
+    target_label  = "controller"
+  }
+
+  // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+      "__meta_kubernetes_pod_label_k8s_app",
+      "__meta_kubernetes_pod_label_app",
+    ]
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "app"
+  }
+}
+
+// grafana memcached scrape job
+prometheus.scrape "memcached" {
+  job_name = coalesce(argument.job_label.value, "integrations/memcached")
+  forward_to = [prometheus.relabel.memcached.receiver]
+  targets = discovery.relabel.memcached.output
+  scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+  scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+
+  clustering {
+    enabled = coalesce(argument.clustering.value, false)
+  }
+}
+
+// memcached metric relabelings (post-scrape)
+prometheus.relabel "memcached" {
+  forward_to = argument.forward_to.value
+  max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+  // keep only metrics that match the keep_metrics regex
+  rule {
+    source_labels = ["__name__"]
+    regex = coalesce(argument.keep_metrics.value, "(up|memcached_(commands_total|connections_total|current_(bytes|connections|items)|items_(evicted_total|total)|max_connections|read_bytes_total|up|uptime_seconds|version|written_bytes_total)
+)")
+    action = "keep"
+  }
+
+}

--- a/modules/kubernetes/metrics/jobs/mimir.river
+++ b/modules/kubernetes/metrics/jobs/mimir.river
@@ -53,7 +53,7 @@ argument "scrape_timeout" {
 }
 
 argument "max_cache_size" {
-  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
   optional = true
 }
 

--- a/modules/kubernetes/metrics/jobs/mimir.river
+++ b/modules/kubernetes/metrics/jobs/mimir.river
@@ -1,0 +1,189 @@
+/*
+Module: job-mimir
+Description: Scrapes mimir
+
+Note: Every argument except for "forward_to" is optional, and does have a defined default value.  However, the values for these
+      arguments are not defined using the default = " ... " argument syntax, but rather using the coalesce(argument.value, " ... ").
+      This is because if the argument passed in from another consuming module is set to null, the default = " ... " syntax will
+      does not override the value passed in, where coalesce() will return the first non-null value.
+*/
+argument "forward_to" {
+  comment = "Must be a list(MetricsReceiver) where collected logs should be forwarded to"
+}
+
+argument "enabled" {
+  comment = "Whether or not the mimir-job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment"
+  optional = true
+}
+
+argument "namespaces" {
+  comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+  optional = true
+}
+
+argument "selectors" {
+  // Docs: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=mimir\",\"app.kubernetes.io/name=enterprise-metrics\"])"
+  optional = true
+}
+
+argument "port_name" {
+  comment = "The of the port to scrape metrics from"
+  optional = true
+}
+
+argument "job_label" {
+  comment = "The job label to add for all mimir-metric (default: integrations/mimir)"
+  optional = true
+}
+
+argument "keep_metrics" {
+  comment = "A regex of metrics to keep (default: see below)"
+  optional = true
+}
+
+argument "scrape_interval" {
+  comment = "How often to scrape metrics from the targets (default: 60s)"
+  optional = true
+}
+
+argument "scrape_timeout" {
+  comment = "How long before a scrape times out (default: 10s)"
+  optional = true
+}
+
+argument "max_cache_size" {
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  optional = true
+}
+
+argument "clustering" {
+  // Docs: https://mimir.com/docs/agent/latest/flow/concepts/clustering/
+  comment = "Whether or not clustering should be enabled (default: false)"
+  optional = true
+}
+
+// mimir service discovery for all of the pods in the mimir daemonset
+discovery.kubernetes "mimir" {
+  role = "pod"
+
+  selectors {
+    role = "pod"
+    label = join(coalesce(argument.selectors.value, [
+      "app.kubernetes.io/name=mimir",
+      "app.kubernetes.io/name=enterprise-logs",
+    ]), ",")
+  }
+
+  namespaces {
+    names = coalesce(argument.namespaces.value, [])
+  }
+}
+
+// mimir relabelings (pre-scrape)
+discovery.relabel "mimir" {
+  targets = discovery.kubernetes.mimir.targets
+
+  // drop all targets if enabled is false
+  rule {
+    target_label = "__enabled"
+    replacement = format("%s", coalesce(argument.enabled.value, "true"))
+  }
+  rule {
+    source_labels = ["__enabled"]
+    regex = "false"
+    action = "drop"
+  }
+
+  // keep only the specified metrics port name, and pods that are Running and ready
+  rule {
+    source_labels = [
+      "__meta_kubernetes_pod_container_port_name",
+      "__meta_kubernetes_pod_phase",
+      "__meta_kubernetes_pod_ready",
+    ]
+    separator = "@"
+    regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true"
+    action = "keep"
+  }
+
+  // set the namespace label
+  rule {
+    source_labels = ["__meta_kubernetes_namespace"]
+    target_label  = "namespace"
+  }
+
+  // set the pod label
+  rule {
+    source_labels = ["__meta_kubernetes_pod_name"]
+    target_label  = "pod"
+  }
+
+  // set the container label
+  rule {
+    source_labels = ["__meta_kubernetes_pod_container_name"]
+    target_label  = "container"
+  }
+
+  // set a controller label
+  rule {
+    source_labels = [
+      "__meta_kubernetes_pod_controller_kind",
+      "__meta_kubernetes_pod_controller_name",
+    ]
+    separator = "/"
+    target_label  = "controller"
+  }
+
+  // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+      "__meta_kubernetes_pod_label_k8s_app",
+      "__meta_kubernetes_pod_label_app",
+    ]
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "app"
+  }
+
+  // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+      "__meta_kubernetes_pod_label_k8s_component",
+      "__meta_kubernetes_pod_label_component",
+    ]
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "app"
+  }
+}
+
+// mimir scrape job
+prometheus.scrape "mimir" {
+  job_name = coalesce(argument.job_label.value, "integrations/mimir")
+  forward_to = [prometheus.relabel.mimir.receiver]
+  targets = discovery.relabel.mimir.output
+  scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+  scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+
+  clustering {
+    enabled = coalesce(argument.clustering.value, false)
+  }
+}
+
+// mimir-metric relabelings (post-scrape)
+prometheus.relabel "mimir" {
+  forward_to = argument.forward_to.value
+  max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+  // keep only metrics that match the keep_metrics regex
+  rule {
+    source_labels = ["__name__"]
+    regex = coalesce(argument.keep_metrics.value, "(.+)")
+    action = "keep"
+  }
+}

--- a/modules/kubernetes/metrics/jobs/node-exporter.river
+++ b/modules/kubernetes/metrics/jobs/node-exporter.river
@@ -1,0 +1,152 @@
+/*
+Module: job-node-exporter
+Description: Scrapes Node Exporter, this is a separate scrape job, if you are also using annotation based scraping, you will want to explicitly
+             disable node-exporter from being scraped by this module and annotations by setting the following annotation on the node-exporter
+             metrics.agent.grafana.com/scrape: "false".
+
+             Node exporter should be deployed as a DaemonSet, each pod on each worker will be scraped by the agent using endpoint service discovery
+
+Note: Every argument except for "forward_to" is optional, and does have a defined default value.  However, the values for these
+      arguments are not defined using the default = " ... " argument syntax, but rather using the coalesce(argument.value, " ... ").
+      This is because if the argument passed in from another consuming module is set to null, the default = " ... " syntax will
+      does not override the value passed in, where coalesce() will return the first non-null value.
+*/
+argument "forward_to" {
+  comment = "Must be a list(MetricsReceiver) where collected logs should be forwarded to"
+  optional = false
+}
+
+argument "enabled" {
+  comment = "Whether or not the node-exporter job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment"
+  optional = true
+}
+
+argument "namespaces" {
+  comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+  optional = true
+}
+
+argument "selectors" {
+  // see: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=prometheus-node-exporter\"])"
+  optional = true
+}
+
+argument "port_name" {
+  comment = "The of the port to scrape metrics from (default: metrics)"
+  optional = true
+}
+
+argument "job_label" {
+  comment = "The job label to add for all node-exporter metrics (default: integrations/node_exporter)"
+  optional = true
+}
+
+argument "keep_metrics" {
+  comment = "A regex of metrics to keep (default: see below)"
+  optional = true
+}
+
+argument "scrape_interval" {
+  comment = "How often to scrape metrics from the targets (default: 60s)"
+  optional = true
+}
+
+argument "scrape_timeout" {
+  comment = "How long before a scrape times out (default: 10s)"
+  optional = true
+}
+
+argument "max_cache_size" {
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  optional = true
+}
+
+argument "clustering" {
+  // Docs: https://grafana.com/docs/agent/latest/flow/concepts/clustering/
+  comment = "Whether or not clustering should be enabled (default: false)"
+  optional = true
+}
+
+// node exporter service discovery for all of the pods in the node exporter daemonset
+discovery.kubernetes "node_exporter" {
+  role = "pod"
+
+  selectors {
+    role = "pod"
+    label = join(coalesce(argument.selectors.value, ["app.kubernetes.io/name=prometheus-node-exporter"]), ",")
+  }
+
+  namespaces {
+    names = coalesce(argument.namespaces.value, [])
+  }
+}
+
+// node exporter relabelings (pre-scrape)
+discovery.relabel "node_exporter" {
+  targets = discovery.kubernetes.node_exporter.targets
+
+  // drop all targets if enabled is false
+  rule {
+    target_label = "__enabled"
+    replacement = format("%s", coalesce(argument.enabled.value, "true"))
+  }
+  rule {
+    source_labels = ["__enabled"]
+    regex = "false"
+    action = "drop"
+  }
+
+  // keep only the specified metrics port name, and pods that are Running and ready
+  rule {
+    source_labels = [
+      "__meta_kubernetes_pod_container_port_name",
+      "__meta_kubernetes_pod_phase",
+      "__meta_kubernetes_pod_ready",
+    ]
+    separator = "@"
+    regex = coalesce(argument.port_name.value, "metrics") + "@Running@true"
+    action = "keep"
+  }
+
+  // copy the pod name to the instance label
+  rule {
+    source_labels = ["__meta_kubernetes_pod_node_name"]
+    action = "replace"
+    target_label = "instance"
+  }
+}
+
+// node exporter scrape job
+prometheus.scrape "node_exporter" {
+  job_name = coalesce(argument.job_label.value, "integrations/node_exporter")
+  forward_to = [prometheus.relabel.node_exporter.receiver]
+  targets = discovery.relabel.node_exporter.output
+  scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+  scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+
+  clustering {
+    enabled = coalesce(argument.clustering.value, false)
+  }
+}
+
+// node-exporter metric relabelings (post-scrape)
+prometheus.relabel "node_exporter" {
+  forward_to = argument.forward_to.value
+  max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+  // keep only metrics that match the keep_metrics regex
+  rule {
+    source_labels = ["__name__"]
+    regex = coalesce(argument.keep_metrics.value, "(up|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|process_cpu_seconds_total|process_resident_memory_bytes)")
+    action = "keep"
+  }
+
+  // Drop metrics for certain file systems
+  rule {
+    source_labels = ["__name__", "fstype"]
+    separator = "@"
+    regex = "node_filesystem.*@(tempfs)"
+    action = "drop"
+  }
+}

--- a/modules/kubernetes/metrics/jobs/node-exporter.river
+++ b/modules/kubernetes/metrics/jobs/node-exporter.river
@@ -58,7 +58,7 @@ argument "scrape_timeout" {
 }
 
 argument "max_cache_size" {
-  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
   optional = true
 }
 

--- a/modules/kubernetes/metrics/jobs/opencost.river
+++ b/modules/kubernetes/metrics/jobs/opencost.river
@@ -56,7 +56,7 @@ argument "scrape_timeout" {
 }
 
 argument "max_cache_size" {
-  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
   optional = true
 }
 

--- a/modules/kubernetes/metrics/jobs/opencost.river
+++ b/modules/kubernetes/metrics/jobs/opencost.river
@@ -1,0 +1,128 @@
+/*
+Module: job-opencost
+Description: Scrapes opencost, this is a separate scrape job, if you are also using annotation based scraping, you will want to explicitly
+             disable opencost from being scraped by this module and annotations by setting the following annotation on the opencost
+             metrics.agent.grafana.com/scrape: "false"
+
+Note: Every argument except for "forward_to" is optional, and does have a defined default value.  However, the values for these
+      arguments are not defined using the default = " ... " argument syntax, but rather using the coalesce(argument.value, " ... ").
+      This is because if the argument passed in from another consuming module is set to null, the default = " ... " syntax will
+      does not override the value passed in, where coalesce() will return the first non-null value.
+*/
+argument "forward_to" {
+  comment = "Must be a list(MetricsReceiver) where collected logs should be forwarded to"
+  optional = false
+}
+
+argument "enabled" {
+  comment = "Whether or not the opencost job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment"
+  optional = true
+}
+
+argument "namespaces" {
+  comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+  optional = true
+}
+
+argument "selectors" {
+  // see: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=opencost\"])"
+  optional = true
+}
+
+argument "port_name" {
+  comment = "The of the port to scrape metrics from (default: http)"
+  optional = true
+}
+
+argument "job_label" {
+  comment = "The job label to add for all opencost metrics (default: integrations/kubernetes/opencost)"
+  optional = true
+}
+
+argument "keep_metrics" {
+  comment = "A regex of metrics to keep"
+  optional = true
+}
+
+argument "scrape_interval" {
+  comment = "How often to scrape metrics from the targets (default: 60s)"
+  optional = true
+}
+
+argument "scrape_timeout" {
+  comment = "How long before a scrape times out (default: 10s)"
+  optional = true
+}
+
+argument "max_cache_size" {
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  optional = true
+}
+
+argument "clustering" {
+  // Docs: https://grafana.com/docs/agent/latest/flow/concepts/clustering/
+  comment = "Whether or not clustering should be enabled (default: false)"
+  optional = true
+}
+
+// opencost service discovery
+discovery.kubernetes "opencost" {
+  role = "service"
+
+  selectors {
+    role = "service"
+    label = join(coalesce(argument.selectors.value, ["app.kubernetes.io/name=opencost"]), ",")
+  }
+
+  namespaces {
+    names = coalesce(argument.namespaces.value, [])
+  }
+}
+
+// opencost relabelings (pre-scrape)
+discovery.relabel "opencost" {
+  targets = discovery.kubernetes.opencost.targets
+
+  // drop all targets if enabled is false
+  rule {
+    target_label = "__enabled"
+    replacement = format("%s", coalesce(argument.enabled.value, "true"))
+  }
+  rule {
+    source_labels = ["__enabled"]
+    regex = "false"
+    action = "drop"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = coalesce(argument.port_name.value, "http")
+    action = "keep"
+  }
+}
+
+// opencost scrape job
+prometheus.scrape "opencost" {
+  job_name = coalesce(argument.job_label.value, "integrations/kubernetes/opencost")
+  forward_to = [prometheus.relabel.opencost.receiver]
+  targets = discovery.relabel.opencost.output
+  scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+  scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+
+  clustering {
+    enabled = coalesce(argument.clustering.value, false)
+  }
+}
+
+// opencost metric relabelings (post-scrape)
+prometheus.relabel "opencost" {
+  forward_to = argument.forward_to.value
+  max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+  rule {
+    source_labels = ["__name__"]
+    regex = coalesce(argument.keep_metrics.value, "(up|container_(cpu|gpu|memory)_allocation(_bytes)?|deployment_match_labels|kubecost_(cluster_(info|management_cost|memory_working_set_bytes)|http_requests_total|http_response_(size_bytes|time_seconds)|load_balancer_cost|network_(internet|region|zone)_egress_cost|node_is_spot)|node_(cpu_hourly_cost|gpu_(count|hourly_cost)|ram_hourly_cost|total_hourly_cost)|opencost_build_info|pod_pvc_allocation|pv_hourly_cost|service_selector_labels|statefulSet_match_labels)")
+    action = "keep"
+  }
+}

--- a/modules/kubernetes/metrics/jobs/prometheus-operator.river
+++ b/modules/kubernetes/metrics/jobs/prometheus-operator.river
@@ -1,0 +1,95 @@
+/*
+Module: job-prometheus operators
+Description: Ingests Prometheus Operator ServiceMonitors, PodMonitors, and Probes
+
+Note: Every argument except for "forward_to" is optional, and does have a defined default value.  However, the values for these
+      arguments are not defined using the default = " ... " argument syntax, but rather using the coalesce(argument.value, " ... ").
+      This is because if the argument passed in from another consuming module is set to null, the default = " ... " syntax will
+      does not override the value passed in, where coalesce() will return the first non-null value.
+*/
+argument "forward_to" {
+  comment = "Must be a list(MetricsReceiver) where collected logs should be forwarded to"
+  optional = false
+}
+
+argument "namespaces" {
+  comment = "List of namespaces to search for prometheus operator resources in (default: [] all namespaces)"
+  optional = true
+}
+
+argument "servicemonitor_namespaces" {
+  comment = "List of namespaces to search for just servicemonitors resources in (default: [] all namespaces)"
+  optional = true
+}
+
+argument "podmonitor_namespaces" {
+  comment = "List of namespaces to search for just podmonitors resources in (default: [] all namespaces)"
+  optional = true
+}
+
+argument "probe_namespaces" {
+  comment = "List of namespaces to search for just probes resources in (default: [] all namespaces)"
+  optional = true
+}
+
+argument "scrape_interval" {
+  comment = "How often to scrape metrics from the targets (default: 60s)"
+  optional = true
+}
+
+argument "clustering" {
+  // Docs: https://grafana.com/docs/agent/latest/flow/concepts/clustering/
+  comment = "Whether or not clustering should be enabled (default: false)"
+  optional = true
+}
+
+// Prometheus Operator ServiceMonitor objects
+prometheus.operator.servicemonitors "service_monitors" {
+  forward_to = argument.forward_to.value
+  namespaces = concat(
+    coalesce(argument.namespaces.value, []),
+    coalesce(argument.servicemonitor_namespaces.value, []),
+  )
+
+  clustering {
+    enabled = coalesce(argument.clustering.value, false)
+  }
+
+  scrape {
+    default_scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+  }
+}
+
+// Prometheus Operator PodMonitor objects
+prometheus.operator.podmonitors "pod_monitors" {
+  forward_to = argument.forward_to.value
+  namespaces = concat(
+    coalesce(argument.namespaces.value, []),
+    coalesce(argument.podmonitor_namespaces.value, []),
+  )
+
+  clustering {
+    enabled = coalesce(argument.clustering.value, false)
+  }
+
+  scrape {
+    default_scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+  }
+}
+
+// Prometheus Operator Probe objects
+prometheus.operator.probes "probes" {
+  forward_to = argument.forward_to.value
+  namespaces = concat(
+    coalesce(argument.namespaces.value, []),
+    coalesce(argument.probe_namespaces.value, []),
+  )
+
+  clustering {
+    enabled = coalesce(argument.clustering.value, false)
+  }
+
+  scrape {
+    default_scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+  }
+}

--- a/modules/kubernetes/metrics/jobs/tempo.river
+++ b/modules/kubernetes/metrics/jobs/tempo.river
@@ -1,0 +1,186 @@
+/*
+Module: job-tempo
+Description: Scrapes tempo
+
+Note: Every argument except for "forward_to" is optional, and does have a defined default value.  However, the values for these
+      arguments are not defined using the default = " ... " argument syntax, but rather using the coalesce(argument.value, " ... ").
+      This is because if the argument passed in from another consuming module is set to null, the default = " ... " syntax will
+      does not override the value passed in, where coalesce() will return the first non-null value.
+*/
+argument "forward_to" {
+  comment = "Must be a list(MetricsReceiver) where collected logs should be forwarded to"
+}
+
+argument "enabled" {
+  comment = "Whether or not the tempo-job should be enabled, this is useful for disabling the job when it is being consumed by other modules in a multi-tenancy environment"
+  optional = true
+}
+
+argument "namespaces" {
+  comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+  optional = true
+}
+
+argument "selectors" {
+  // Docs: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=tempo\",\"app.kubernetes.io/name=enterprise-metrics\"])"
+  optional = true
+}
+
+argument "port_name" {
+  comment = "The of the port to scrape metrics from (default: http-metrics)"
+  optional = true
+}
+
+argument "job_label" {
+  comment = "The job label to add for all tempo-metric (default: integrations/tempo)"
+  optional = true
+}
+
+argument "keep_metrics" {
+  comment = "A regex of metrics to keep (default: see below)"
+  optional = true
+}
+
+argument "scrape_interval" {
+  comment = "How often to scrape metrics from the targets (default: 60s)"
+  optional = true
+}
+
+argument "scrape_timeout" {
+  comment = "How long before a scrape times out (default: 10s)"
+  optional = true
+}
+
+argument "max_cache_size" {
+  comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  Only increase if the amount of metrics returned is extremely large, the default will almost always be sufficient"
+  optional = true
+}
+
+argument "clustering" {
+  // Docs: https://tempo.com/docs/agent/latest/flow/concepts/clustering/
+  comment = "Whether or not clustering should be enabled (default: false)"
+  optional = true
+}
+
+// tempo service discovery for all of the pods in the tempo daemonset
+discovery.kubernetes "tempo" {
+  role = "pod"
+
+  selectors {
+    role = "pod"
+    label = join(coalesce(argument.selectors.value, ["app.kubernetes.io/name=tempo"]), ",")
+  }
+
+  namespaces {
+    names = coalesce(argument.namespaces.value, [])
+  }
+}
+
+// tempo relabelings (pre-scrape)
+discovery.relabel "tempo" {
+  targets = discovery.kubernetes.tempo.targets
+
+  // drop all targets if enabled is false
+  rule {
+    target_label = "__enabled"
+    replacement = format("%s", coalesce(argument.enabled.value, "true"))
+  }
+  rule {
+    source_labels = ["__enabled"]
+    regex = "false"
+    action = "drop"
+  }
+
+  // keep only the specified metrics port name, and pods that are Running and ready
+  rule {
+    source_labels = [
+      "__meta_kubernetes_pod_container_port_name",
+      "__meta_kubernetes_pod_phase",
+      "__meta_kubernetes_pod_ready",
+    ]
+    separator = "@"
+    regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true"
+    action = "keep"
+  }
+
+  // set the namespace label
+  rule {
+    source_labels = ["__meta_kubernetes_namespace"]
+    target_label  = "namespace"
+  }
+
+  // set the pod label
+  rule {
+    source_labels = ["__meta_kubernetes_pod_name"]
+    target_label  = "pod"
+  }
+
+  // set the container label
+  rule {
+    source_labels = ["__meta_kubernetes_pod_container_name"]
+    target_label  = "container"
+  }
+
+  // set a controller label
+  rule {
+    source_labels = [
+      "__meta_kubernetes_pod_controller_kind",
+      "__meta_kubernetes_pod_controller_name",
+    ]
+    separator = "/"
+    target_label  = "controller"
+  }
+
+  // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+      "__meta_kubernetes_pod_label_k8s_app",
+      "__meta_kubernetes_pod_label_app",
+    ]
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "app"
+  }
+
+  // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+      "__meta_kubernetes_pod_label_k8s_component",
+      "__meta_kubernetes_pod_label_component",
+    ]
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "app"
+  }
+}
+
+// tempo scrape job
+prometheus.scrape "tempo" {
+  job_name = coalesce(argument.job_label.value, "integrations/tempo")
+  forward_to = [prometheus.relabel.tempo.receiver]
+  targets = discovery.relabel.tempo.output
+  scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+  scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+
+  clustering {
+    enabled = coalesce(argument.clustering.value, false)
+  }
+}
+
+// tempo-metric relabelings (post-scrape)
+prometheus.relabel "tempo" {
+  forward_to = argument.forward_to.value
+  max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+  // keep only metrics that match the keep_metrics regex
+  rule {
+    source_labels = ["__name__"]
+    regex = coalesce(argument.keep_metrics.value, "(.+)")
+    action = "keep"
+  }
+}


### PR DESCRIPTION
Reduced complexity of modules and created specific self contained jobs.  Leaving existing modules in place to not break any current users. 