### PR TITLE
Fix(kubernetes): fix log-formats incorrect path

### DIFF
--- a/modules/kubernetes/logs/log-formats/all.river
+++ b/modules/kubernetes/logs/log-formats/all.river
@@ -118,7 +118,7 @@ module.git "log_format_postgres" {
   repository = argument.git_repo.value
   revision = argument.git_rev.value
   pull_frequency = argument.git_pull_freq.value
-  path = "modules/kubernetes/logs/log-formats/otel.river"
+  path = "modules/kubernetes/logs/log-formats/postgres.river"
 
   arguments {
     forward_to = [module.git.log_format_python.exports.process.receiver]
@@ -162,7 +162,7 @@ module.git "log_format_zerolog" {
   repository = argument.git_repo.value
   revision = argument.git_rev.value
   pull_frequency = argument.git_pull_freq.value
-  path = "modules/kubernetes/logs/log-formats/spring-boot.river"
+  path = "modules/kubernetes/logs/log-formats/zerolog.river"
 
   arguments {
     forward_to = argument.forward_to.value

--- a/modules/kubernetes/logs/targets/logs-from-api.river
+++ b/modules/kubernetes/logs/targets/logs-from-api.river
@@ -8,6 +8,12 @@ argument "forward_to" {
   optional = false
 }
 
+argument "tenant" {
+  // comment = "The tenant to filter logs to.  This does not have to be the tenantId, this is the value to look for in the logs.agent.grafana.com/tenant annotation, and this can be a regex."
+  optional = true
+  default = ".*"
+}
+
 argument "git_repo" {
   optional = true
   default = coalesce(env("GIT_REPO"), "https://github.com/grafana/agent-modules.git")


### PR DESCRIPTION
fix incorrect path
```
module.git "log_format_postgres" {
...
  - path = "modules/kubernetes/logs/log-formats/otel.river"
  + path = "modules/kubernetes/logs/log-formats/postgres.river"
...
}
```